### PR TITLE
Added cache-control header

### DIFF
--- a/lib/asset_sync/asset_sync.rb
+++ b/lib/asset_sync/asset_sync.rb
@@ -58,7 +58,8 @@ module AssetSync
       file = bucket.files.create(
         :key => "#{f}",
         :body => File.open("#{path}/#{f}"),
-        :public => true
+        :public => true,
+        'Cache-Control' => 'max-age=29030400, public'
       )
     end
 


### PR DESCRIPTION
Added setting of Cache-control header (1 year, public) when uploading assets to s3, so the client gets the cache-control header when requesting the file from s3/cloudfront.

Let me know what you think 

Cheers
