### PR TITLE
Fixes asset_sync to correctly read manifest.yml files.

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -41,8 +41,9 @@ module AssetSync
     end
 
     def manifest_path
-      default = File.join(Rails.root, 'public', assets_prefix, 'manifest.yml')
-      Rails.application.config.assets.manifest || default
+      directory =
+        Rails.application.config.assets.manifest || default_manifest_directory
+      "#{directory}/manifest.yml"
     end
 
     def gzip?
@@ -133,5 +134,10 @@ module AssetSync
       return options
     end
 
+  private
+
+    def default_manifest_directory
+      File.join(Rails.root, 'public', assets_prefix)
+    end
   end
 end

--- a/spec/asset_sync_spec.rb
+++ b/spec/asset_sync_spec.rb
@@ -138,7 +138,7 @@ describe AssetSync do
     end
 
     it "config.manifest_path should default to public/assets.." do
-      Rails.application.config.assets.manifest = "/var/assets/manifest.yml"
+      Rails.application.config.assets.manifest = "/var/assets"
       AssetSync.config.manifest_path.should == "/var/assets/manifest.yml"
     end
 


### PR DESCRIPTION
`Rails.config.assets.manifest` only points to the directory that contains the `manifest.yml` file:

https://github.com/rails/rails/blob/226783d1e8891a38d4a61017952528970dba903d/actionpack/lib/sprockets/railtie.rb#L36

If you have a manifest.yml file in a non-standard location (say `config/assets/manifest.yml`), this patch makes sure that we can read that manifest file in.
