### PR TITLE
Cache the YML config to avoid multiple file reads.

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -71,7 +71,7 @@ module AssetSync
     end
 
     def yml
-      y ||= YAML.load(ERB.new(IO.read(yml_path)).result)[Rails.env] rescue nil || {}
+      @yml ||= YAML.load(ERB.new(IO.read(yml_path)).result)[Rails.env] rescue nil || {}
     end
 
     def yml_path


### PR DESCRIPTION
This was not being cached, as `y` was a local method variable.
