### PR TITLE
Always provide mime_type when uploading, even for non-gzipped files

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -104,10 +104,13 @@ module AssetSync
 
     def upload_file(f)
       # TODO output files in debug logs as asset filename only.
+      ext = File.extname( f )[1..-1]
+      mime = Mime::Type.lookup_by_extension( ext )
       file = {
         :key => f,
         :body => File.open("#{path}/#{f}"),
         :public => true,
+        :content_type     => mime,
         :cache_control => "public, max-age=31557600",
         :expires => CGI.rfc1123_date(Time.now + 1.year)
       }
@@ -126,12 +129,9 @@ module AssetSync
 
         if gzipped_size < original_size
           percentage = ((gzipped_size.to_f/original_size.to_f)*100).round(2)
-          ext = File.extname( f )[1..-1]
-          mime = Mime::Type.lookup_by_extension( ext )
           file.merge!({
             :key => f,
             :body => File.open(gzipped),
-            :content_type     => mime,
             :content_encoding => 'gzip'
           })
           log "Uploading: #{gzipped} in place of #{f} saving #{percentage}%"


### PR DESCRIPTION
This fixes a bug I'm having where some video files are uploaded to s3/cloudfront and get a mime type of 
application/mp4 rather than video/mp4. With this fix I am able to add this next line to my config/initializers/mime_types.rb file:
Mime::Type.register "video/mp4", :mp4, [], ['mp4']

and then I get the correct mime type showing up on the mp4 files in S3.
