### PR TITLE
Remove Rails time dependency

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -109,7 +109,7 @@ module AssetSync
         :body => File.open("#{path}/#{f}"),
         :public => true,
         :cache_control => "public, max-age=31557600",
-        :expires => CGI.rfc1123_date(Time.now + 1.year)
+        :expires => CGI.rfc1123_date(Time.now + 31556926)
       }
 
       gzipped = "#{path}/#{f}.gz"


### PR DESCRIPTION
A simple change to try and make asset_sync more compatible as a standalone asset sync solution, much along the same lines as the [Sinatra](https://github.com/rumblelabs/asset_sync/pull/92) branch
