### PR TITLE
Added support for new manifest format used by turbo-sprockets-rails3, and possibly Rails

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -60,9 +60,11 @@ module AssetSync
     def get_local_files
       if self.config.manifest
         if File.exists?(self.config.manifest_path)
-          yml = YAML.load(IO.read(self.config.manifest_path))
+          yml = YAML.load_file(self.config.manifest_path)
           log "Using: Manifest #{self.config.manifest_path}"
-          return yml.values.map { |f| File.join(self.config.assets_prefix, f) }
+          # Support for new manifest format used by turbo-sprockets-rails3
+          files = yml[:digest_files] ? yml[:digest_files] : yml
+          return files.values.map { |f| File.join(self.config.assets_prefix, f) }
         else
           log "Warning: manifest.yml not found at #{self.config.manifest_path}"
         end


### PR DESCRIPTION
Hi there,

I've recently developed a gem that speeds up the asset compilation task, called [turbo-sprockets-rails3](https://github.com/ndbroadbent/turbo-sprockets-rails3). 
In order for it to do its magic, it needs to alter the `manifest.yml` format to include both `:source_digests` and `:digest_files`, instead of a flat digest files hash.

This pull request simply looks for the presence of the `:digest_files` key in `manifest.yml`, and falls back to the old format it it's not found, so it should be 100% backwards compatible.

Note that I'm also trying to get the patch merged into Rails 4.0.0, and possibly Rails 3.2.9 (see https://github.com/rails/sprockets-rails/pull/21). Even if it's not merged into Rails for some reason, I would really appreciate it if you could support the users of the turbo-sprockets-rails3 gem.

Thanks for your time!
