### PR TITLE
Add ability to declare custom headers

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -14,6 +14,7 @@ module AssetSync
     attr_accessor :prefix
     attr_accessor :public_path
     attr_accessor :enabled
+    attr_accessor :custom_headers
 
     # FOG configuration
     attr_accessor :fog_provider          # Currently Supported ['AWS', 'Rackspace']
@@ -49,6 +50,7 @@ module AssetSync
       self.fail_silently = false
       self.always_upload = []
       self.ignored_files = []
+      self.custom_headers = {}
       self.enabled = true
       load_yml! if defined?(Rails) && yml_exists?
     end
@@ -126,6 +128,7 @@ module AssetSync
       self.fail_silently          = yml["fail_silently"] if yml.has_key?("fail_silently")
       self.always_upload          = yml["always_upload"] if yml.has_key?("always_upload")
       self.ignored_files          = yml["ignored_files"] if yml.has_key?("ignored_files")
+      self.custom_headers         = yml["custom_headers"] if yml.has_key?("custom_headers")
 
       # TODO deprecate the other old style config settings. FML.
       self.aws_access_key_id      = yml["aws_access_key"] if yml.has_key?("aws_access_key")

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -57,6 +57,10 @@ module AssetSync
       self.config.always_upload.map { |f| File.join(self.config.assets_prefix, f) }
     end
 
+    def files_with_custom_headers
+      self.config.custom_headers.inject({}) { |h,(k, v)| h[File.join(self.config.assets_prefix, k)] = v; h; }
+    end
+
     def get_local_files
       if self.config.manifest
         if File.exists?(self.config.manifest_path)
@@ -115,6 +119,11 @@ module AssetSync
         :expires => CGI.rfc1123_date(Time.now + one_year),
         :content_type => mime
       }
+      # overwrite headers if applicable, you probably shouldn't specific key/body, but cache-control headers etc.
+      if files_with_custom_headers.has_key? f
+        file.merge! files_with_custom_headers[f]
+        log "Overwriting #{f} with custom headers #{files_with_custom_headers[f].to_s}"
+      end
 
       gzipped = "#{path}/#{f}.gz"
       ignore = false
@@ -170,6 +179,7 @@ module AssetSync
     def sync
       # fixes: https://github.com/rumblelabs/asset_sync/issues/19
       log "AssetSync: Syncing."
+      log files_with_custom_headers.to_json
       upload_files
       delete_extra_remote_files unless keep_existing_remote_files?
       log "AssetSync: Done."


### PR DESCRIPTION
As mentioned in my question #119, I wanted to ask about the ability to declare custom headers for short-lived assets. This is my first pull-request, so please bare with me. 

The way I approached it is to allow to set a hash, where the key is the file name, and the value is a hash of headers. Please let me know if there is something else I can do.
