### PR TITLE
Make asset_sync's upload compatible with non-rails projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 Gemfile.lock
 pkg/*
 *.swp
+.rvmrc
+.idea

--- a/asset_sync.gemspec
+++ b/asset_sync.gemspec
@@ -16,8 +16,10 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "asset_sync"
 
+  s.add_dependency('mime-types')
   s.add_dependency('fog')
   s.add_dependency('activemodel')
+
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "bundler"

--- a/lib/asset_sync.rb
+++ b/lib/asset_sync.rb
@@ -1,4 +1,5 @@
 require 'fog'
+require 'mime/types'
 require 'active_model'
 require 'erb'
 require "asset_sync/asset_sync"

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -105,8 +105,7 @@ module AssetSync
     def upload_file(f)
       # TODO output files in debug logs as asset filename only.
       one_year = 31557600
-      ext = File.extname(f)[1..-1]
-      mime = Mime::Type.lookup_by_extension(ext)
+      mime = MIME::Types.type_for(f).join(', ')
       file = {
         :key => f,
         :body => File.open("#{path}/#{f}"),


### PR DESCRIPTION
Mime::Type is Rails specific which stands in the way of enabling gzip compression in middleman-sync

This fixes the problem.
There will also be a patch for middelman sync to switch on the gzip-compression option
