### PR TITLE
Upload non-fingerprinted version of updated assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ spec/dummy_app/public/*
 spec/dummy_app/log/*
 spec/dummy_app/tmp/*
 .rbx
+.rvmrc
+.idea

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -1,7 +1,9 @@
 module AssetSync
   class Storage
+    REGEXP_FINGERPRINTED_FILES = /^(.*)\/([^-]+)-[^\.]+\.([^\.]+)$/
 
-    class BucketNotFound < StandardError; end
+    class BucketNotFound < StandardError;
+    end
 
     attr_accessor :config
 
@@ -22,6 +24,10 @@ module AssetSync
       AssetSync.log(msg)
     end
 
+    def keep_existing_remote_files?
+      self.config.existing_remote_files?
+    end
+
     def path
       self.config.public_path
     end
@@ -30,16 +36,16 @@ module AssetSync
       files = []
       Array(self.config.ignored_files).each do |ignore|
         case ignore
-        when Regexp
-          files += self.local_files.select do |file|
-            file =~ ignore
-          end
-        when String
-          files += self.local_files.select do |file|
-            file.split('/').last == ignore
-          end
-        else
-          log "Error: please define ignored_files as string or regular expression. #{ignore} (#{ignore.class}) ignored."
+          when Regexp
+            files += self.local_files.select do |file|
+              file =~ ignore
+            end
+          when String
+            files += self.local_files.select do |file|
+              file.split('/').last == ignore
+            end
+          else
+            log "Error: please define ignored_files as string or regular expression. #{ignore} (#{ignore.class}) ignored."
         end
       end
       files.uniq
@@ -137,15 +143,15 @@ module AssetSync
         ignore = true
       elsif config.gzip? && File.exists?(gzipped)
         original_size = File.size("#{path}/#{f}")
-        gzipped_size  = File.size(gzipped)
+        gzipped_size = File.size(gzipped)
 
         if gzipped_size < original_size
           percentage = ((gzipped_size.to_f/original_size.to_f)*100).round(2)
           file.merge!({
-            :key => f,
-            :body => File.open(gzipped),
-            :content_encoding => 'gzip'
-          })
+                        :key => f,
+                        :body => File.open(gzipped),
+                        :content_encoding => 'gzip'
+                      })
           log "Uploading: #{gzipped} in place of #{f} saving #{percentage}%"
         else
           percentage = ((original_size.to_f/gzipped_size.to_f)*100).round(2)
@@ -180,7 +186,7 @@ module AssetSync
       remote_files = ignore_existing_remote_files? ? [] : get_remote_files
       # fixes: https://github.com/rumblelabs/asset_sync/issues/19
       local_files_to_upload = local_files - ignored_files - remote_files + always_upload_files
-      local_files_to_upload = add_non_fingerprinted(local_files_to_upload)
+      local_files_to_upload = (local_files_to_upload + get_non_fingerprinted(local_files_to_upload)).uniq
 
       # Upload new files
       local_files_to_upload.each do |f|
@@ -199,31 +205,16 @@ module AssetSync
 
     private
 
-    def keep_existing_remote_files?
-      self.config.existing_remote_files?
-    end
-
     def ignore_existing_remote_files?
       self.config.existing_remote_files == 'ignore'
     end
 
-    def add_non_fingerprinted(files)
-      fingerprinted = select_fingerprinted(files)
-      non_fingerprinted = fingerprinted.map do |file|
-        # Check for files matching .../filename-fingerprint.ext
-        regexp = /^(.*)\/([^-]+)-[^\.]+\.([^\.]+)$/
-        match_data = file.match(regexp)
-        "#{match_data[1]}/#{match_data[2]}.#{match_data[3]}"
-      end
-      files + non_fingerprinted
+    def get_non_fingerprinted(files)
+      files.map do |file|
+        match_data = file.match(REGEXP_FINGERPRINTED_FILES)
+        match_data && "#{match_data[1]}/#{match_data[2]}.#{match_data[3]}"
+      end.compact
     end
 
-    def select_fingerprinted(files)
-      files.select do |file|
-        # Check for files matching .../filename-fingerprint.ext
-        regexp = /\/[^-]+-[^\.]+\.[^\.]+$/
-        file.match(regexp)
-      end
-    end
   end
 end

--- a/spec/unit/storage_spec.rb
+++ b/spec/unit/storage_spec.rb
@@ -50,6 +50,38 @@ describe AssetSync::Storage do
       storage.upload_files
     end
 
+    it 'should upload updated non-fingerprinted files' do
+      @local_files = [
+        'public/image.png',
+        'public/image-82389298328.png',
+        'public/image-a8389f9h324.png',
+        'public/application.js',
+        'public/application-b3389d983k1.js',
+        'public/application-ac387d53f31.js',
+        'public',
+      ]
+      @remote_files = [
+        'public/image.png',
+        'public/image-a8389f9h324.png',
+        'public/application.js',
+        'public/application-b3389d983k1.js',
+      ]
+
+      storage = AssetSync::Storage.new(@config)
+      storage.stub(:local_files).and_return(@local_files)
+      storage.stub(:get_remote_files).and_return(@remote_files)
+      File.stub(:file?).and_return(true) # Pretend they all exist
+
+      updated_nonfingerprinted_files = [
+        'public/image.png',
+        'public/application.js',
+      ]
+      (@local_files - @remote_files + updated_nonfingerprinted_files).each do |file|
+        storage.should_receive(:upload_file).with(file)
+      end
+      storage.upload_files
+    end
+
     it 'should correctly set expire date' do
       local_files = ['file1.jpg', 'file1-1234567890abcdef1234567890abcdef.jpg']
       local_files += ['dir1/dir2/file2.jpg', 'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg']


### PR DESCRIPTION
Altered filtering for keeping files to exclude non-fingerprinted files from being kept since they get updated too on asset compilation and thus need to be uploaded (useful for outside app references to assets)

For example, we have a case where we need to reference an image by the non-fingerprinted name (e.g. image.png) outside the Rails app, so it would be nice to just reference the S3 link. However, when the designer updates the image and has the asset_sync upload to S3, only the fingerprinted version goes out (e.g. image-82389298328.png). This diff fixes the problem by uploading the updated non-fingerprinted version of the image too.
