### PR TITLE
Better defaults for asset_sync.yml generator

### DIFF
--- a/lib/generators/asset_sync/templates/asset_sync.yml
+++ b/lib/generators/asset_sync/templates/asset_sync.yml
@@ -27,12 +27,15 @@ defaults: &defaults
 
 development:
   <<: *defaults
+  enabled: false
 
 test:
   <<: *defaults
+  enabled: false
 
 staging:
   <<: *defaults
+  fog_directory: "<%= app_name %>-staging-assets"
 
 production:
   <<: *defaults


### PR DESCRIPTION
Disable asset_sync in `development` and `test` environments
Set a different `fog_directory` for `staging` from `production`

(per #136)
