### PR TITLE
Set expire date only for assets with fingerprint.

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -111,10 +111,14 @@ module AssetSync
         :key => f,
         :body => File.open("#{path}/#{f}"),
         :public => true,
-        :cache_control => "public, max-age=#{one_year}",
-        :expires => CGI.rfc1123_date(Time.now + one_year),
         :content_type => mime
       }
+      if /-[0-9a-fA-F]{32}$/.match(File.basename(f,File.extname(f)))
+        file.merge!({
+          :cache_control => "public, max-age=#{one_year}",
+          :expires => CGI.rfc1123_date(Time.now + one_year)
+        })
+      end
 
       gzipped = "#{path}/#{f}.gz"
       ignore = false

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -50,5 +50,43 @@ describe AssetSync::Storage do
       end
       storage.upload_files
     end
+
+    it 'should correctly set expire date' do
+      local_files = ['file1.jpg', 'file1-1234567890abcdef1234567890abcdef.jpg']
+      local_files += ['dir1/dir2/file2.jpg', 'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg']
+      remote_files = []
+      storage = AssetSync::Storage.new(@config)
+      storage.stub(:local_files).and_return(local_files)
+      storage.stub(:get_remote_files).and_return(remote_files)
+      File.stub(:file?).and_return(true)
+      File.stub(:open).and_return(nil)
+
+      module Mime
+        module Type
+          def self.lookup_by_extension(extension)
+          end
+        end
+      end
+
+      def check_file(file)
+        case file[:key]
+        when 'file1.jpg'
+        when 'dir1/dir2/file2.jpg'
+          !file.should_not include(:cache_control, :expires)
+        when 'file1-1234567890abcdef1234567890abcdef.jpg'
+        when 'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg'
+          file.should include(:cache_control, :expires)
+        else
+          fail
+        end
+      end
+
+      files = double()
+      local_files.count.times do
+        files.should_receive(:create) { |file| check_file(file) }
+      end
+      storage.stub_chain(:bucket, :files).and_return(files)
+      storage.upload_files
+    end
   end
 end


### PR DESCRIPTION
It would be nice to set expire date after 1 year only for assets that have a fingerprint. Otherwise, no expire date should be set.
