### PR TITLE
Replace deprecated yaml configuration mentioned in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Or via YAML
 ``` yaml
 production:
   # ...
-  aws_region: 'eu-west-1'
+  fog_region: 'eu-west-1'
 ```
 
 


### PR DESCRIPTION
I noticed `aws_region` was mentioned in an example in the README but from browsing the source I see it's the old style setting and `fog_region` is the new one. It confused me initially, so I thought it best to update the readme.
