### PR TITLE
Updated README for non default S3 bucket region and bucket subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Or
 ```
 On **non default S3 bucket region**: If your bucket is set to a region that is not the default US Standard (us-east-1) you must use the first style of url ``//#{ENV['FOG_DIRECTORY']}.s3.amazonaws.com`` or amazon will return a 301 permanently moved when assets are requested. Note the caveat above about bucket names and periods. 
 
+If you wish to have your assets sync to a sub-folder of your bucket instead of into the root add the following to your ``production.rb`` file
+
+```ruby
+  # store assets in a 'folder' instead of bucket root
+  config.assets.prefix = "/production/assets"
+````
+
 Also, ensure the following are defined (in production.rb or application.rb)
 
 * **config.assets.digest** is set to **true**.


### PR DESCRIPTION
Added into the readme an explanation of which url to use if your using an s3 bucket other than the default.

Also added in an example of how to set up production.rb so that your assets will be synced to a folder within a bucket allowing for multiple environments ie productions/staging to have assets in the same bucket.
