### PR TITLE
Do not overwrite config with ENV if ENV variable not present

### DIFF
--- a/lib/asset_sync/engine.rb
+++ b/lib/asset_sync/engine.rb
@@ -13,34 +13,34 @@ module AssetSync
       elsif !File.exists?( app_initializer ) && !File.exists?( app_yaml )
         AssetSync.log "AssetSync: using default configuration from built-in initializer"
         AssetSync.configure do |config|
-          config.fog_provider = ENV['FOG_PROVIDER']
-          config.fog_directory = ENV['FOG_DIRECTORY']
-          config.fog_region = ENV['FOG_REGION']
+          config.fog_provider = ENV['FOG_PROVIDER'] if ENV.has_key?('FOG_PROVIDER')
+          config.fog_directory = ENV['FOG_DIRECTORY'] if ENV.has_key?('FOG_DIRECTORY')
+          config.fog_region = ENV['FOG_REGION'] if ENV.has_key?('FOG_REGION')
 
-          config.aws_access_key_id = ENV['AWS_ACCESS_KEY_ID']
-          config.aws_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
-          config.aws_reduced_redundancy = ENV['AWS_REDUCED_REDUNDANCY'] == true
+          config.aws_access_key_id = ENV['AWS_ACCESS_KEY_ID'] if ENV.has_key?('AWS_ACCESS_KEY_ID')
+          config.aws_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY'] if ENV.has_key?('AWS_SECRET_ACCESS_KEY')
+          config.aws_reduced_redundancy = ENV['AWS_REDUCED_REDUNDANCY'] == true  if ENV.has_key?('AWS_REDUCED_REDUNDANCY')
 
-          config.rackspace_username = ENV['RACKSPACE_USERNAME']
-          config.rackspace_api_key = ENV['RACKSPACE_API_KEY']
+          config.rackspace_username = ENV['RACKSPACE_USERNAME'] if ENV.has_key?('RACKSPACE_USERNAME')
+          config.rackspace_api_key = ENV['RACKSPACE_API_KEY'] if ENV.has_key?('RACKSPACE_API_KEY')
 
-          config.google_storage_access_key_id = ENV['GOOGLE_STORAGE_ACCESS_KEY_ID']
-          config.google_storage_secret_access_key = ENV['GOOGLE_STORAGE_SECRET_ACCESS_KEY']
+          config.google_storage_access_key_id = ENV['GOOGLE_STORAGE_ACCESS_KEY_ID'] if ENV.has_key?('GOOGLE_STORAGE_ACCESS_KEY_ID')
+          config.google_storage_secret_access_key = ENV['GOOGLE_STORAGE_SECRET_ACCESS_KEY'] if ENV.has_key?('GOOGLE_STORAGE_SECRET_ACCESS_KEY')
 
-          if ENV.has_key? 'ASSET_SYNC_ENABLED'
-            config.enabled = ENV['ASSET_SYNC_ENABLED'] == 'true'
-          end
+          config.enabled = (ENV['ASSET_SYNC_ENABLED'] == 'true') if ENV.has_key?('ASSET_SYNC_ENABLED')
+
           config.existing_remote_files = ENV['ASSET_SYNC_EXISTING_REMOTE_FILES'] || "keep"
-          config.gzip_compression = ENV['ASSET_SYNC_GZIP_COMPRESSION'] == 'true'
-          config.manifest = ENV['ASSET_SYNC_MANIFEST'] == 'true'
+
+          config.gzip_compression = (ENV['ASSET_SYNC_GZIP_COMPRESSION'] == 'true') if ENV.has_key?('ASSET_SYNC_GZIP_COMPRESSION')
+          config.manifest = (ENV['ASSET_SYNC_MANIFEST'] == 'true') if ENV.has_key?('ASSET_SYNC_MANIFEST')
         end
 
-        if ENV.has_key? 'ASSET_SYNC_PREFIX'
-          config.prefix = ENV['ASSET_SYNC_PREFIX']
-        end
+        config.prefix = ENV['ASSET_SYNC_PREFIX'] if ENV.has_key?('ASSET_SYNC_PREFIX')
+
         config.existing_remote_files = ENV['ASSET_SYNC_EXISTING_REMOTE_FILES'] || "keep"
-        config.gzip_compression = ENV['ASSET_SYNC_GZIP_COMPRESSION'] == 'true'
-        config.manifest = ENV['ASSET_SYNC_MANIFEST'] == 'true'
+
+        config.gzip_compression = (ENV['ASSET_SYNC_GZIP_COMPRESSION'] == 'true') if ENV.has_key?('ASSET_SYNC_GZIP_COMPRESSION')
+        config.manifest = (ENV['ASSET_SYNC_MANIFEST'] == 'true') if ENV.has_key?('ASSET_SYNC_MANIFEST')
 
       end
 


### PR DESCRIPTION
Hello,

I have a case where I don't want to use `ENV['FOG_PROVIDER']` for setting the fog_provider because the variable name isn't right for me. Same thing with variables such as `ENV['AWS_ACCESS_KEY_ID']` that can conflict with other AWS credentials.

Using Rails + Heroku, I would like to be able to do

```
  config.asset_sync.fog_provider = 'AWS'
```

in my environment file.

The problem is that this would get overwritten by the environment variable, enven if it's empty. My commit changes that.

Other option would be:

```
config.fog_provider ||= ENV['FOG_PROVIDER']
```

Let me know if you'd prefer this and I'll make another PR.

Thanks for the gem
