### PR TITLE
Call #uniq on the list of files to ensure files are not uploaded twice.

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -50,7 +50,7 @@ module AssetSync
     end
 
     def local_files
-      @local_files ||= get_local_files
+      @local_files ||= get_local_files.uniq
     end
 
     def always_upload_files


### PR DESCRIPTION
When I run `assets:precompile` for my project the manifest contains lines like:

``` yml
application.js: application-abcdefghijklmnopqrstuvwxyz123456.js
application/index.js: application-abcdefghijklmnopqrstuvwxyz123456.js
```

When using asset_sync with the `manifest` option enabled, this results in duplicate entries in the `local_files` array.  This patch simply calls `Array#uniq` after finding local files to remove these duplicates.
