### PR TITLE
Don't delete files that are always uploaded.

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -97,7 +97,7 @@ module AssetSync
       log "Fetching files to flag for delete"
       remote_files = get_remote_files
       # fixes: https://github.com/rumblelabs/asset_sync/issues/19
-      from_remote_files_to_delete = remote_files - local_files - ignored_files
+      from_remote_files_to_delete = remote_files - local_files - ignored_files - always_upload_files
 
       log "Flagging #{from_remote_files_to_delete.size} file(s) for deletion"
       # Delete unneeded remote files


### PR DESCRIPTION
As part of our deployment process we want to upload our asset manifest to S3.  To do so we have added `manifest.yml` to `config.always_upload`.

However, when using a combination of `config.manifest = true` and `config.existing_remote_files = 'delete'` this file would always deleted from S3, as `manifest.yml` is not seen as a local file.

A simple fix for this is to remove `always_upload_files` from the list of files to be deleted, which seems to make sense.
