### PR TITLE
Fixes issue where AssetSync’s Config class assumes Rails.root is defined. 

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -88,7 +88,7 @@ module AssetSync
     end
 
     def yml_exists?
-      File.exists?(self.yml_path)
+      defined?(Rails.root) ? File.exists?(self.yml_path) : false
     end
 
     def yml


### PR DESCRIPTION
It resolves the following middleman-sync issue:

https://github.com/karlfreeman/middleman-sync/issues/18

Note: If Rails is undefined, it assumes you’re not using YAML configuration.
