### PR TITLE
can configure the public_path to store the assets before upload

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -142,6 +142,8 @@ module AssetSync
       self.aws_secret_access_key  = yml["secret_access_key"] if yml.has_key?("secret_access_key")
       self.fog_directory          = yml["bucket"] if yml.has_key?("bucket")
       self.fog_region             = yml["region"] if yml.has_key?("region")
+
+      self.public_path            = yml["public_path"] if yml.has_key?("public_path")
     end
 
 


### PR DESCRIPTION
by default it is stored under the public folder which in my opinion
is messy for git status

also my public folder has files like 404.html and robots.txt
only want files under asset-pipeline to be synced
