### PR TITLE
Fail silently if asset_sync is disabled

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -72,7 +72,7 @@ module AssetSync
     end
 
     def fail_silently?
-      fail_silently == true
+      fail_silently || !enabled?
     end
 
     def enabled?

--- a/spec/unit/asset_sync_spec.rb
+++ b/spec/unit/asset_sync_spec.rb
@@ -157,6 +157,20 @@ describe AssetSync do
     end
   end
 
+  describe 'with disabled config' do
+    before(:each) do
+      AssetSync.stub(:stderr).and_return(@stderr = StringIO.new)
+      AssetSync.config = AssetSync::Config.new
+      AssetSync.configure do |config|
+        config.enabled = false
+      end
+    end
+
+    it "should not raise an invalid exception" do
+      lambda{ AssetSync.sync }.should_not raise_error(AssetSync::Config::Invalid)
+    end
+  end
+
   describe 'with gzip_compression enabled' do
     before(:each) do
       AssetSync.config = AssetSync::Config.new


### PR DESCRIPTION
If asset_sync is disabled, we shouldn't expect to have a valid configuration file as we don't need it.
This prevents the library from raising an exception for things like "Aws access secret can't be blank" when the library is disabled, where we won't need them anyway.
