### PR TITLE
Use the fog :rackspace_region config

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -168,6 +168,9 @@ module AssetSync
           :rackspace_username => rackspace_username,
           :rackspace_api_key => rackspace_api_key
         })
+        options.merge!({
+          :rackspace_region => fog_region
+        }) if fog_region
         options.merge!({ :rackspace_auth_url => rackspace_auth_url }) if rackspace_auth_url
       elsif google?
         options.merge!({
@@ -178,7 +181,7 @@ module AssetSync
         raise ArgumentError, "AssetSync Unknown provider: #{fog_provider} only AWS and Rackspace are supported currently."
       end
 
-      options.merge!({:region => fog_region}) if fog_region
+      options.merge!({:region => fog_region}) if fog_region && !rackspace?
       return options
     end
 


### PR DESCRIPTION
Fixes #185

Looks like the [fog gem added a config option](https://github.com/fog/fog/issues/1135) called `:rackspace_region` for specifying wether to use Chicago or Dallas.  

This lets users set the FOG_REGION like normal, but it will turn it into `:rackspace_region` underneath.
