### PR TITLE
Added Ruby 2.0 to list of platforms in the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source :rubygems
 gemspec
 gem 'rcov',      :platforms => :mri_18, :group => [:development, :test]
-gem 'simplecov', :platforms => [:jruby, :mri_19, :ruby_19, :rbx], :group => [:development, :test], :require => false
+gem 'simplecov', :platforms => [:jruby, :mri_19, :ruby_19, :mri_20, :rbx], :group => [:development, :test], :require => false
 gem 'jruby-openssl', :platform => :jruby


### PR DESCRIPTION
Added :mri_20 in the Gemfile so it doesn't miss installing SimpleCov when trying to run the tests on Ruby 2.0
