### PR TITLE
Allow config to be reset (removes memoized values)

### DIFF
--- a/lib/asset_sync/asset_sync.rb
+++ b/lib/asset_sync/asset_sync.rb
@@ -12,7 +12,7 @@ module AssetSync
     end
 
     def reset_config!
-      remove_instance_variable :@config
+      remove_instance_variable :@config if defined?(@config)
     end
 
     def configure(&proc)


### PR DESCRIPTION
Hi, I think this might be helpful to do multiple runs within one scrypt/process. e.g:

```
AssetSync.config.prefix = "assets"
AssetSync.sync
AssetSync.reset_config!
AssetSync.config.prefix = "deprecated_assets"
AssetSync.sync
```

Let me know what you think, thank you!
