### PR TITLE
Set Expires and Cache-Control headers for .gz files

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -136,7 +136,9 @@ module AssetSync
         :content_type => mime
       }
 
-      if /-[0-9a-fA-F]{32}$/.match(File.basename(f,File.extname(f)))
+      uncompressed_filename = f.sub(/\.gz\z/, '')
+      basename = File.basename(uncompressed_filename, File.extname(uncompressed_filename))
+      if /-[0-9a-fA-F]{32}$/.match(basename)
         file.merge!({
           :cache_control => "public, max-age=#{one_year}",
           :expires => CGI.rfc1123_date(Time.now + one_year)

--- a/spec/unit/storage_spec.rb
+++ b/spec/unit/storage_spec.rb
@@ -84,8 +84,10 @@ describe AssetSync::Storage do
 
 
     it 'should correctly set expire date' do
-      local_files = ['file1.jpg', 'file1-1234567890abcdef1234567890abcdef.jpg']
-      local_files += ['dir1/dir2/file2.jpg', 'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg']
+      local_files = ['file1.jpg', 'file1-1234567890abcdef1234567890abcdef.jpg',
+        'file1-1234567890abcdef1234567890abcdef.jpg.gz']
+      local_files += ['dir1/dir2/file2.jpg', 'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg',
+        'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg.gz']
       remote_files = []
       storage = AssetSync::Storage.new(@config)
       storage.stub(:local_files).and_return(local_files)
@@ -100,6 +102,8 @@ describe AssetSync::Storage do
           !file.should_not include(:cache_control, :expires)
         when 'file1-1234567890abcdef1234567890abcdef.jpg'
         when 'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg'
+        when 'file1-1234567890abcdef1234567890abcdef.jpg.gz'
+        when 'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg.gz'
           file.should include(:cache_control, :expires)
         else
           fail


### PR DESCRIPTION
Currently regular files have caching headers set, but that doesn't work for .gz files. This pull request fixes that by stripping .gz extension when testing for a digest hash presence.