### PR TITLE
Add unf as a dependency as it is now optional in fog.

### DIFF
--- a/asset_sync.gemspec
+++ b/asset_sync.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "asset_sync"
 
   s.add_dependency('fog', ">= 1.8.0")
+  s.add_dependency('unf')
   s.add_dependency('activemodel')
 
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Relates to #234.

I didn't actually mean to send this yet.  I haven't tested it myself (I meant to send the PR to myself as I have a fork running) but I think it is the simplest fix.
