### PR TITLE
Set path_style for S3 bucket name with dots

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -113,6 +113,10 @@ module AssetSync
       defined?(Rails.root) ? File.exists?(self.yml_path) : false
     end
 
+    def path_style?
+      fog_directory.include?('.')
+    end
+
     def yml
       begin
         @yml ||= YAML.load(ERB.new(IO.read(yml_path)).result)[Rails.env] rescue nil || {}
@@ -188,6 +192,9 @@ module AssetSync
             :aws_secret_access_key => aws_secret_access_key
           })
         end
+        options.merge!({
+          :path_style => true
+        }) if path_style?
       elsif rackspace?
         options.merge!({
           :rackspace_username => rackspace_username,

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -114,7 +114,7 @@ module AssetSync
     end
 
     def path_style?
-      fog_directory.include?('.')
+      fog_directory && fog_directory.include?('.')
     end
 
     def yml

--- a/spec/unit/asset_sync_spec.rb
+++ b/spec/unit/asset_sync_spec.rb
@@ -227,6 +227,23 @@ describe AssetSync do
     end
   end
 
+  describe 'with periods included bucket name' do
+    before(:each) do
+      AssetSync.config = AssetSync::Config.new
+      AssetSync.config.fog_provider = "AWS"
+      AssetSync.config.fog_directory = "bucket.with.dots"
+    end
+
+    it "config.path_style? should be true" do
+      expect(AssetSync.config).to be_path_style
+    end
+
+    it "path_style? in fog_option should be true" do
+      expect(AssetSync.config.fog_options[:path_style]).to be_truthy
+    end
+
+  end
+
   describe 'with invalid yml' do
 
     before(:each) do


### PR DESCRIPTION
Recently I updated my fog bundled version and got errors when syncing assets. After digging to the codes, I found several discussions about S3 bucket name with dots included. Ref: fog/fog#2381 

Adding `:path_style= > true` for `fog_options` when `fog_directory` contains dots would fix this issue.

This pul request closes #237.
