### PR TITLE
Add setting to control the public ACL on uploaded files

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ AssetSync.configure do |config|
   # Increase upload performance by configuring your region
   # config.fog_region = 'eu-west-1'
   #
+  # Set fog_public to false if you prefer to use bucket policies instead of ACLs
+  # config.fog_public = true
+  #
   # Automatically replace files with their equivalent gzip compressed version
   # config.gzip_compression = true
   #
@@ -228,6 +231,8 @@ defaults: &defaults
   aws_secret_access_key: "<%= ENV['AWS_SECRET_ACCESS_KEY'] %>"
   # You may need to specify what region your storage bucket is in
   # fog_region: "eu-west-1"
+  # Set fog_public to false if you prefer to use bucket policies instead of ACLs
+  # fog_public: true
   existing_remote_files: keep # Existing pre-compiled assets on S3 will be kept
   # To delete existing remote files.
   # existing_remote_files: delete
@@ -284,6 +289,7 @@ AssetSync.config.gzip_compression == ENV['ASSET_SYNC_GZIP_COMPRESSION']
 #### Fog (Optional)
 
 * **fog\_region**: the region your storage bucket is in e.g. *eu-west-1*
+* **fog\_public**: (`true, false`) when true, sets the public ACL on files during upload. **default:** `'true'`
 
 #### AWS
 

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -24,6 +24,7 @@ module AssetSync
     attr_accessor :fog_provider          # Currently Supported ['AWS', 'Rackspace']
     attr_accessor :fog_directory         # e.g. 'the-bucket-name'
     attr_accessor :fog_region            # e.g. 'eu-west-1'
+    attr_accessor :fog_public            # Public ACL, true or false
 
     # Amazon AWS
     attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_reduced_redundancy
@@ -48,6 +49,7 @@ module AssetSync
 
     def initialize
       self.fog_region = nil
+      self.fog_public = true
       self.existing_remote_files = 'keep'
       self.gzip_compression = false
       self.manifest = false
@@ -135,6 +137,7 @@ module AssetSync
       self.fog_provider           = yml["fog_provider"]
       self.fog_directory          = yml["fog_directory"]
       self.fog_region             = yml["fog_region"]
+      self.fog_public             = yml["fog_public"] if yml.has_key?('fog_public')
       self.aws_access_key_id      = yml["aws_access_key_id"]
       self.aws_secret_access_key  = yml["aws_secret_access_key"]
       self.aws_reduced_redundancy = yml["aws_reduced_redundancy"]

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -132,7 +132,7 @@ module AssetSync
       file = {
         :key => f,
         :body => File.open("#{path}/#{f}"),
-        :public => true,
+        :public => self.config.fog_public,
         :content_type => mime
       }
 

--- a/lib/generators/asset_sync/templates/asset_sync.rb
+++ b/lib/generators/asset_sync/templates/asset_sync.rb
@@ -26,6 +26,9 @@ AssetSync.configure do |config|
   # Increase upload performance by configuring your region
   # config.fog_region = 'eu-west-1'
   #
+  # Set fog_public to false if you prefer to use bucket policies instead of ACLs
+  # config.fog_public = true
+  #
   # Don't delete files from the store
   # config.existing_remote_files = "keep"
   #

--- a/lib/generators/asset_sync/templates/asset_sync.yml
+++ b/lib/generators/asset_sync/templates/asset_sync.yml
@@ -19,6 +19,8 @@ defaults: &defaults
   fog_directory: "<%= app_name %>-assets"
   # You may need to specify what region your storage bucket is in
   # fog_region: "eu-west-1"
+  # Set fog_public to false if you prefer to use bucket policies instead of ACLs
+  # fog_public: true
   existing_remote_files: keep
   # To delete existing remote files.
   # existing_remote_files: delete


### PR DESCRIPTION
Taking a page from [CarrierWave](https://github.com/carrierwaveuploader/carrierwave)'s book, I added a `fog_public` config option to control the setting of the public ACL on uploaded files.

This would solve #208 for people who prefer to use bucket policies instead of ACLs.