### PR TITLE
Support using AWS IAM Roles

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -26,7 +26,7 @@ module AssetSync
     attr_accessor :fog_region            # e.g. 'eu-west-1'
 
     # Amazon AWS
-    attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_reduced_redundancy, :aws_iam_role
+    attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_reduced_redundancy, :aws_iam_roles
 
     # Rackspace
     attr_accessor :rackspace_username, :rackspace_api_key, :rackspace_auth_url
@@ -86,7 +86,7 @@ module AssetSync
     end
 
     def aws_iam?
-      aws_iam_role == true
+      aws_iam_roles == true
     end
 
     def fail_silently?
@@ -142,7 +142,7 @@ module AssetSync
       self.aws_access_key_id      = yml["aws_access_key_id"]
       self.aws_secret_access_key  = yml["aws_secret_access_key"]
       self.aws_reduced_redundancy = yml["aws_reduced_redundancy"]
-      self.aws_iam_role           = yml["aws_iam_role"]
+      self.aws_iam_roles          = yml["aws_iam_roles"]
       self.rackspace_username     = yml["rackspace_username"]
       self.rackspace_auth_url     = yml["rackspace_auth_url"] if yml.has_key?("rackspace_auth_url")
       self.rackspace_api_key      = yml["rackspace_api_key"]


### PR DESCRIPTION
This adds support for setting a config option(aws_iam_role) and passing along the correct value to fog.

It takes advantage of IAM Roles(http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) which are a way to give instances access to resources without storing your credentials on your instances.

I've got a copy of the AWS integration test with the only change being the settings and it works.  I can commit that as well, but since it only runs from an instance with an IAM Role I didn't think it made sense to be a regular spec.
