### PR TITLE
Add `fog_additional_options` to AssetSync::Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ AssetSync.config.gzip_compression == ENV['ASSET_SYNC_GZIP_COMPRESSION']
 #### Fog (Optional)
 
 * **fog\_region**: the region your storage bucket is in e.g. *eu-west-1*
+* **fog\_additional\_options**: additional options to pass to Fog e.g. `{ :path_style => true }`
 
 #### AWS
 

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -24,6 +24,7 @@ module AssetSync
     attr_accessor :fog_provider          # Currently Supported ['AWS', 'Rackspace']
     attr_accessor :fog_directory         # e.g. 'the-bucket-name'
     attr_accessor :fog_region            # e.g. 'eu-west-1'
+    attr_accessor :fog_additional_options
 
     # Amazon AWS
     attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_reduced_redundancy
@@ -196,6 +197,7 @@ module AssetSync
       end
 
       options.merge!({:region => fog_region}) if fog_region && !rackspace?
+      options.merge! fog_additional_options || {}
       return options
     end
 

--- a/spec/unit/asset_sync_spec.rb
+++ b/spec/unit/asset_sync_spec.rb
@@ -12,6 +12,7 @@ describe AssetSync do
         config.aws_secret_access_key = 'bbbb'
         config.fog_directory = 'mybucket'
         config.fog_region = 'eu-west-1'
+        config.fog_additional_options = { path_style: true }
         config.existing_remote_files = "keep"
       end
     end
@@ -48,6 +49,10 @@ describe AssetSync do
 
     it "should configure fog_region" do
       AssetSync.config.fog_region.should == "eu-west-1"
+    end
+
+    it "should configure fog_additional_options" do
+      AssetSync.config.fog_options[:path_style].should == true
     end
 
     it "should configure existing_remote_files" do


### PR DESCRIPTION
Fog supports more configuration options than just those we can configure directly with `AssetSync::Config`.

I added the `fog_additional_options` accessor that get merged at the end of `fog_options` so we won’t have to add an accessor everytime Fog gets updated with new configuration variables.
