### PR TITLE
Fix for @yml being nil

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -115,7 +115,7 @@ module AssetSync
 
     def yml
       begin
-        @yml ||= YAML.load(ERB.new(IO.read(yml_path)).result)[Rails.env] rescue nil || {}
+        @yml ||= YAML.load(ERB.new(IO.read(yml_path)).result)[Rails.env] || {}
       rescue Psych::SyntaxError
         @yml = {}
       end

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -114,11 +114,9 @@ module AssetSync
     end
 
     def yml
-      begin
-        @yml ||= YAML.load(ERB.new(IO.read(yml_path)).result)[Rails.env] || {}
-      rescue Psych::SyntaxError
-        @yml = {}
-      end
+      @yml ||= YAML.load(ERB.new(IO.read(yml_path)).result)[Rails.env] || {}
+    rescue Psych::SyntaxError
+      @yml = {}
     end
 
     def yml_path


### PR DESCRIPTION
When there's no settings specified for the Rails.env that you are running, @yml will get the value nil. I got that error when running my tests and not specifying any settings for the test environment.

The rescue at the ending of line 114 in config.rb looked a little suspicious, the value incase of an exception would always have been {} and that rescue case would catch all exceptions, making the "rescue Psych::SyntaxError useless."

So maybe this solution is more inline with the intention of the writer, if the YAML.load... is nil set it to {}.
