### PR TITLE
Removing rails double to prevent leak

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,7 @@ end
 
 shared_context "mock Rails" do
   before(:each) do
+    Object.send(:remove_const, :Rails) if defined? Rails
     Rails = double 'Rails'
     Rails.stub(:env).and_return('test')
     Rails.stub :application => double('application')


### PR DESCRIPTION
Tests are failing on Travis, a great many of them because it is seeing Rails as a leaked double.

This PR fixes that.
