### PR TITLE
Remove instance variable @storage when resetting the config

### DIFF
--- a/lib/asset_sync/asset_sync.rb
+++ b/lib/asset_sync/asset_sync.rb
@@ -13,6 +13,7 @@ module AssetSync
 
     def reset_config!
       remove_instance_variable :@config if defined?(@config)
+      remove_instance_variable :@storage if defined?(@storage)
     end
 
     def configure(&proc)


### PR DESCRIPTION
The storage object will reference the config used when it was created. So resetting the config should also reset the storage object.
