### PR TITLE
When choosing files to upload from dir, make sure if there is no prefix ...

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -91,7 +91,8 @@ module AssetSync
       end
       log "Using: Directory Search of #{path}/#{self.config.assets_prefix}"
       Dir.chdir(path) do
-        Dir["#{self.config.assets_prefix}/**/**"]
+        to_load = self.config.assets_prefix.present? ? "#{self.config.assets_prefix}/**/**" : '**/**'
+        Dir[to_load]
       end
     end
 


### PR DESCRIPTION
I discovered that if I am not using the manifest, or a prefix, then you try to load `Dir['/**/**']` which is every file on the computer, but then, even worse, it fails silently and nothing gets uploaded.
