### PR TITLE
Enable concurrent (threaded) uploading of files

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -19,6 +19,7 @@ module AssetSync
     attr_accessor :run_on_precompile
     attr_accessor :invalidate
     attr_accessor :cdn_distribution_id
+    attr_accessor :concurrent_uploads
 
     # FOG configuration
     attr_accessor :fog_provider          # Currently Supported ['AWS', 'Rackspace']
@@ -45,6 +46,7 @@ module AssetSync
     validates :rackspace_api_key,     :presence => true, :if => :rackspace?
     validates :google_storage_secret_access_key,  :presence => true, :if => :google?
     validates :google_storage_access_key_id,      :presence => true, :if => :google?
+    validates :concurrent_uploads,    :inclusion => { :in => [true, false] }
 
     def initialize
       self.fog_region = nil
@@ -59,6 +61,7 @@ module AssetSync
       self.enabled = true
       self.run_on_precompile = true
       self.cdn_distribution_id = nil
+      self.concurrent_uploads = true
       self.invalidate = []
       load_yml! if defined?(Rails) && yml_exists?
     end

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -212,12 +212,20 @@ module AssetSync
       # fixes: https://github.com/rumblelabs/asset_sync/issues/19
       local_files_to_upload = local_files - ignored_files - remote_files + always_upload_files
       local_files_to_upload = (local_files_to_upload + get_non_fingerprinted(local_files_to_upload)).uniq
+      # keep track of threads for uploading
+      threads = ThreadGroup.new
 
       # Upload new files
       local_files_to_upload.each do |f|
         next unless File.file? "#{path}/#{f}" # Only files.
-        upload_file f
+        if self.config.concurrent_uploads
+          threads.add(Thread.new { upload_file f })
+        else
+          upload_file f
+        end
       end
+
+      sleep 1 while threads.list.any? # wait for threads to finish uploading
 
       if self.config.cdn_distribution_id && files_to_invalidate.any?
         log "Invalidating Files"

--- a/spec/unit/storage_spec.rb
+++ b/spec/unit/storage_spec.rb
@@ -107,9 +107,7 @@ describe AssetSync::Storage do
       end
 
       files = double()
-      local_files.count.times do
-        expect(files).to receive(:create) { |file| check_file(file) }
-      end
+      expect(files).to receive(:create){ |file| check_file(file) }.exactly(local_files.count).times
       allow(storage).to receive_message_chain(:bucket, :files).and_return(files)
       storage.upload_files
     end


### PR DESCRIPTION
Uploading assets can take more than a few minutes for sufficiently large legacy apps (like the one I work on).

When testing this out locally, I tried with an entirely empty bucket, and our compiled assets is ~40mb.  With the threaded uploads, it took about 1 minute. After emptying out the bucket and trying again without threads, it took about 30 minutes.

This can be a bit more taxing on system resources, so I built this feature so that it could be turned off with a config setting.
