### PR TITLE
Added fog_path_style option

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -24,6 +24,7 @@ module AssetSync
     attr_accessor :fog_provider          # Currently Supported ['AWS', 'Rackspace']
     attr_accessor :fog_directory         # e.g. 'the-bucket-name'
     attr_accessor :fog_region            # e.g. 'eu-west-1'
+    attr_accessor :fog_path_style        # enable/disable path_style
 
     # Amazon AWS
     attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_reduced_redundancy, :aws_iam_roles
@@ -207,6 +208,7 @@ module AssetSync
       end
 
       options.merge!({:region => fog_region}) if fog_region && !rackspace?
+      options.merge!({:path_style => fog_path_style})
       return options
     end
 

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -7,6 +7,7 @@ module AssetSync
     # AssetSync
     attr_accessor :existing_remote_files # What to do with your existing remote files? (keep or delete)
     attr_accessor :gzip_compression
+    attr_accessor :uncompressable_files
     attr_accessor :manifest
     attr_accessor :fail_silently
     attr_accessor :log_silently
@@ -51,6 +52,7 @@ module AssetSync
       self.fog_region = nil
       self.existing_remote_files = 'keep'
       self.gzip_compression = false
+      self.uncompressable_files = []
       self.manifest = false
       self.fail_silently = false
       self.log_silently = true

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -126,6 +126,8 @@ module AssetSync
     end
 
     def upload_file(f)
+      log "Processing: #{f}"
+
       # TODO output files in debug logs as asset filename only.
       one_year = 31557600
       ext = File.extname(f)[1..-1]

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -1,6 +1,6 @@
 module AssetSync
   class Storage
-    REGEXP_FINGERPRINTED_FILES = /^(.*)\/([^-]+)-[^\.]+\.([^\.]+)$/
+    REGEXP_FINGERPRINTED_FILES = /^([^-]+)-[^\.]+\.([^\.]+)$/
 
     class BucketNotFound < StandardError;
     end
@@ -247,7 +247,7 @@ module AssetSync
     def get_non_fingerprinted(files)
       files.map do |file|
         match_data = file.match(REGEXP_FINGERPRINTED_FILES)
-        match_data && "#{match_data[1]}/#{match_data[2]}.#{match_data[3]}"
+        match_data && "#{match_data[1]}.#{match_data[2]}"
       end.compact
     end
 

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -56,7 +56,12 @@ module AssetSync
     end
 
     def always_upload_files
-      self.config.always_upload.map { |f| File.join(self.config.assets_prefix, f) }
+      Dir.chdir(path) do
+        self.config.always_upload.map { |f| 
+          to_load = self.config.assets_prefix.present? ? File.join(self.config.assets_prefix, f) : f
+          Dir[to_load]
+        }.flatten
+      end
     end
 
     def files_with_custom_headers

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -76,7 +76,7 @@ module AssetSync
         elsif File.exist?(self.config.manifest_path)
           log "Using: Manifest #{self.config.manifest_path}"
           yml = YAML.load(IO.read(self.config.manifest_path))
-   
+
           return yml.map do |original, compiled|
             # Upload font originals and compiled
             if original =~ /^.+(eot|svg|ttf|woff)$/
@@ -169,7 +169,7 @@ module AssetSync
         # as we will overwrite file.css with file.css.gz if it exists.
         log "Ignoring: #{f}"
         ignore = true
-      elsif config.gzip? && File.exist?(gzipped)
+      elsif config.gzip? && File.exist?(gzipped) && can_be_compressed?(f)
         original_size = File.size("#{path}/#{f}")
         gzipped_size = File.size(gzipped)
 
@@ -251,5 +251,8 @@ module AssetSync
       end.compact
     end
 
+    def can_be_compressed?(file)
+      config.uncompressable_files.none? {|pattern| file.match pattern }
+    end
   end
 end


### PR DESCRIPTION
This will suppress the warnings like "[fog][WARNING] fog: the specified s3 bucket name(www.example.com) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html"
