### PR TITLE
Add AWS IAM to build-in initializer

### DIFF
--- a/lib/asset_sync/engine.rb
+++ b/lib/asset_sync/engine.rb
@@ -20,6 +20,7 @@ module AssetSync
           config.aws_access_key_id = ENV['AWS_ACCESS_KEY_ID'] if ENV.has_key?('AWS_ACCESS_KEY_ID')
           config.aws_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY'] if ENV.has_key?('AWS_SECRET_ACCESS_KEY')
           config.aws_reduced_redundancy = ENV['AWS_REDUCED_REDUNDANCY'] == true  if ENV.has_key?('AWS_REDUCED_REDUNDANCY')
+          config.aws_iam_roles = ENV['AWS_IAM_ROLES'] == true if ENV.has_kay?('AWS_IAM_ROLES')
 
           config.rackspace_username = ENV['RACKSPACE_USERNAME'] if ENV.has_key?('RACKSPACE_USERNAME')
           config.rackspace_api_key = ENV['RACKSPACE_API_KEY'] if ENV.has_key?('RACKSPACE_API_KEY')


### PR DESCRIPTION
This fix is required to improve configuration with environment variables.
