### PR TITLE
Document aws_iam_roles configuration option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ AssetSync.config.gzip_compression == ENV['ASSET_SYNC_GZIP_COMPRESSION']
 
 * **aws\_access\_key\_id**: your Amazon S3 access key
 * **aws\_secret\_access\_key**: your Amazon S3 access secret
+* **aws_iam_roles**: use IAM role instead of access keys
 
 #### Rackspace
 


### PR DESCRIPTION
I had trouble getting asset_sync to work on AWS after migrating away from user based policies to role based. I eventually found the aws_iam_roles configuration option by digging into the code and now it all works.

I think having the aws_iam_roles option documented in the readme along with the other AWS options would have saved me some time.