### PR TITLE
Using fog-aws instead of fog as dependency

### DIFF
--- a/asset_sync.gemspec
+++ b/asset_sync.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "asset_sync"
 
-  s.add_dependency('fog', ">= 1.8.0")
+  s.add_dependency('fog-aws', ">= 0.1.0")
   s.add_dependency('unf')
   s.add_dependency('activemodel')
 

--- a/lib/asset_sync.rb
+++ b/lib/asset_sync.rb
@@ -1,4 +1,4 @@
-require 'fog' unless defined?(::Fog)
+require 'fog/aws/storage'
 require 'active_model'
 require 'erb'
 require "asset_sync/asset_sync"


### PR DESCRIPTION
Please don't merge this yet. I'm opening the PR so travis tests it :)

As discussed in #292, this is a possible solution to use `fog-aws` instead of `fog`.
As `fog-aws` is fairily new, there are a couple of problems:
- probably users of old versions of fog would have to update to at least [1.27](https://github.com/fog/fog-aws/blob/2604076bcfd6692e656b8b87629b13dfcc43f076/fog-aws.gemspec#L26). That shouldn't be a problem, though, because fog [follows semantic versioning](https://github.com/fog/fog/blob/a1130dff1fdf1da33c0ce88838f0b7e4a2b8fe24/README.md#versioning)
- I'm not sure of what's an appropiate version to use as a minimum version for `fog-aws` so I just chose the most recent one.
