### PR TITLE
Add fog path_style option support

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -24,6 +24,7 @@ module AssetSync
     attr_accessor :fog_provider          # Currently Supported ['AWS', 'Rackspace']
     attr_accessor :fog_directory         # e.g. 'the-bucket-name'
     attr_accessor :fog_region            # e.g. 'eu-west-1'
+    attr_accessor :fog_path_style        # true or false, true allows bucket names with dots
 
     # Amazon AWS
     attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_reduced_redundancy, :aws_iam_roles
@@ -139,6 +140,7 @@ module AssetSync
       self.fog_provider           = yml["fog_provider"]
       self.fog_directory          = yml["fog_directory"]
       self.fog_region             = yml["fog_region"]
+      self.fog_path_style         = yml["fog_path_style"]
       self.aws_access_key_id      = yml["aws_access_key_id"]
       self.aws_secret_access_key  = yml["aws_secret_access_key"]
       self.aws_reduced_redundancy = yml["aws_reduced_redundancy"]
@@ -176,7 +178,7 @@ module AssetSync
 
 
     def fog_options
-      options = { :provider => fog_provider }
+      options = { :provider => fog_provider, path_style: fog_path_style }
       if aws?
         if aws_iam?
           options.merge!({


### PR DESCRIPTION
Currently super-ugly monkey patching is required to support `path_style`. There were already few pull requests to support this options, but they seem to be unmergable already and probably outdated. 