### PR TITLE
gzip files before upload, fix header setting

### DIFF
--- a/asset_sync.gemspec
+++ b/asset_sync.gemspec
@@ -2,6 +2,7 @@
 $:.push File.expand_path("../lib", __FILE__)
 
 require "asset_sync/version"
+require "zlib"
 
 Gem::Specification.new do |s|
   s.name        = "asset_sync"

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -7,6 +7,7 @@ module AssetSync
     # AssetSync
     attr_accessor :existing_remote_files # What to do with your existing remote files? (keep or delete)
     attr_accessor :gzip_compression
+    attr_accessor :extensions_to_gzip
     attr_accessor :manifest
     attr_accessor :fail_silently
     attr_accessor :log_silently
@@ -50,6 +51,7 @@ module AssetSync
       self.fog_region = nil
       self.existing_remote_files = 'keep'
       self.gzip_compression = false
+      self.extensions_to_gzip = 'css,js'
       self.manifest = false
       self.fail_silently = false
       self.log_silently = true

--- a/lib/asset_sync/engine.rb
+++ b/lib/asset_sync/engine.rb
@@ -32,6 +32,7 @@ module AssetSync
           config.existing_remote_files = ENV['ASSET_SYNC_EXISTING_REMOTE_FILES'] || "keep"
 
           config.gzip_compression = (ENV['ASSET_SYNC_GZIP_COMPRESSION'] == 'true') if ENV.has_key?('ASSET_SYNC_GZIP_COMPRESSION')
+          config.extensions_to_gzip = ENV['ASSET_SYNC_EXTENSIONS_TO_GZIP'] if ENV.has_key?('ASSET_SYNC_EXTENSIONS_TO_GZIP')
           config.manifest = (ENV['ASSET_SYNC_MANIFEST'] == 'true') if ENV.has_key?('ASSET_SYNC_MANIFEST')
         end
 

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -210,16 +210,17 @@ module AssetSync
     end
 
     def compress_files
-      self.local_files.each do |f|
-        unless File.extname(f) == '.gz'
-          file = File.join(path, f)
-          gz_path = file + ".gz"
-          unless File.exist?(gz_path)
+      extensions_to_gzip = Regexp.union(*config.extensions_to_gzip.split(','))
+      self.local_files.each do |file|
+        if File.extname(file)[1..-1] =~ extensions_to_gzip
+          file_path = File.join(path, file)
+          if File.file?(file_path)
+            gz_path = file_path + ".gz"
             log "Writing #{gz_path}"
             Zlib::GzipWriter.open(gz_path, Zlib::BEST_COMPRESSION) do |gz|
-              gz.mtime = File.mtime(file)
-              gz.orig_name = file
-              gz.write(IO.binread(file))
+              gz.mtime = File.mtime(file_path)
+              gz.orig_name = file_path
+              gz.write(IO.binread(file_path))
             end
           end
         end

--- a/spec/dummy_app/app/assets/javascripts/application.js
+++ b/spec/dummy_app/app/assets/javascripts/application.js
@@ -1,1 +1,10 @@
-console.log("hello");
+var ipsum = "Lorem ipsum dolor sit amet, mel lobortis volutpat reformidans eu. Neglegentur mediocritatem pri eu, eu per ignota probatus. Vis facilisi posidonium et, id eum numquam sapientem. Ignota minimum id per, rebum persius nominati sed id. \
+ \
+Ad mea simul perfecto patrioque. Id sumo etiam evertitur per, iisque lucilius ne mei. In pro mentitum deserunt. Per cu nibh nominavi, ne pro velit ponderum verterem, dolor perpetua sit eu. \
+ \
+Ei nec sanctus vivendo. Saepe partiendo vix ne. Stet labitur ut his, ei tibique vivendum quo. His iuvaret qualisque ex, at rebum fierent prodesset eos. Sit enim soluta et. \
+ \
+Eripuit abhorreant efficiantur at his. Ex duo putent aliquip adipisci. Ea albucius vivendum mel, ex alienum omittantur vim. Illum ridens utroque at usu, vix at adhuc simul, elit possim oblique sit id. Posse postea gubergren eum at, qui in wisi option splendide, liber assentior disputando ei vix. An quo clita definiebas, sed possit pericula cu, tamquam accusata at vim."
+
+console.log(ipsum);
+

--- a/spec/unit/storage_spec.rb
+++ b/spec/unit/storage_spec.rb
@@ -84,8 +84,8 @@ describe AssetSync::Storage do
 
 
     it 'should correctly set expire date' do
-      local_files = ['file1.jpg', 'file1-1234567890abcdef1234567890abcdef.jpg']
-      local_files += ['dir1/dir2/file2.jpg', 'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg']
+      local_files = ['file1.jpg', 'file1-1234567890abcdef1234567890abcdef.jpg', 'file1-1234567890abcdef1234567890abcdef.jpg.gz']
+      local_files += ['dir1/dir2/file2.jpg', 'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg', 'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg.gz']
       remote_files = []
       storage = AssetSync::Storage.new(@config)
       allow(storage).to receive(:local_files).and_return(local_files)
@@ -99,7 +99,9 @@ describe AssetSync::Storage do
         when 'dir1/dir2/file2.jpg'
           !expect(file).not_to include(:cache_control, :expires)
         when 'file1-1234567890abcdef1234567890abcdef.jpg'
+        when 'file1-1234567890abcdef1234567890abcdef.jpg.gz'
         when 'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg'
+        when 'dir1/dir2/file2-1234567890abcdef1234567890abcdef.jpg.gz'
           expect(file).to include(:cache_control, :expires)
         else
           fail

--- a/spec/unit/storage_spec.rb
+++ b/spec/unit/storage_spec.rb
@@ -193,4 +193,24 @@ describe AssetSync::Storage do
       #Object.send(:remove_const, :MIME) if defined?(MIME)
     end
   end
+
+  describe '#compress_files' do
+    before(:each) do
+      @config = AssetSync::Config.new
+      @config.public_path = 'public'
+    end
+
+    it 'should compress text files' do
+      local_files = ['jquery.js', 'file1.jpg', 'application.css', 'logo.png',  'dir']
+      storage = AssetSync::Storage.new(@config)
+      allow(storage).to receive(:local_files).and_return(local_files)
+      allow(File).to receive(:file?).and_return(true)
+      allow(File).to receive(:open).and_return(nil)
+
+      expect(Zlib::GzipWriter).to receive(:open).with('public/application.css.gz', anything).and_return(nil)
+      expect(Zlib::GzipWriter).to receive(:open).with('public/jquery.js.gz', anything).and_return(nil)
+      storage.compress_files
+    end
+
+  end
 end


### PR DESCRIPTION
since Sprockets 3 no longer gzips assets for us
(https://github.com/sstephenson/sprockets/commit/d388ef7cc0e36e710539fb11799d7e5518609d61)
, we can do it here (#304) prior to upload. Also fix the pre-detection of
filename in upload_file so the cache_control and expires header get set
properly on the gzipped files (#308).

/ht to @mirzali for the rake task patch that was modified for use here, and @wpiekutowski for the Cache-control header setting code.

(this also fixes 1 failing integration test and moves the content-encoding header detection to that test) 