### PR TITLE
Fix asset_prefix when using a manifest

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -126,8 +126,10 @@ module AssetSync
     end
 
     def assets_prefix
-      # Fix for Issue #38 when Rails.config.assets.prefix starts with a slash
-      self.prefix || Rails.application.config.assets.prefix.sub(/^\//, '')
+      self.prefix || (
+        prefix = Rails.application.config.assets.prefix.sub(/^\//, '')
+        File.extname(prefix) == "" ? prefix : File.dirname(prefix)
+      )
     end
 
     def public_path


### PR DESCRIPTION
The Rails.config.assets.prefix writes a manifest if the last item has an
extname.

See
https://github.com/rails/sprockets/blob/d22339a6d8dfa13f1c49663ad09bc1cc6a1cdcc3/lib/sprockets/manifest.rb#L43-L45