### PR TITLE
Allow over 32 chars length hash digest

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -137,7 +137,7 @@ module AssetSync
         :content_type => mime
       }
 
-      if /-[0-9a-fA-F]{32}$/.match(File.basename(f,File.extname(f)))
+      if /-[0-9a-fA-F]{32,}$/.match(File.basename(f,File.extname(f)))
         file.merge!({
           :cache_control => "public, max-age=#{one_year}",
           :expires => CGI.rfc1123_date(Time.now + one_year)


### PR DESCRIPTION
Sprockets 3 appends 64 chars length digest.

> Default digest changed to SHA256.

see: https://github.com/rails/sprockets/tree/v3.0.0#version-history