### PR TITLE
Fix config.log_silently?

### DIFF
--- a/lib/asset_sync/asset_sync.rb
+++ b/lib/asset_sync/asset_sync.rb
@@ -57,7 +57,7 @@ module AssetSync
     end
 
     def log(msg)
-      stdout.puts msg if config.log_silently?
+      stdout.puts msg unless config.log_silently?
     end
 
     def enabled?

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -94,7 +94,7 @@ module AssetSync
     end
 
     def log_silently?
-      ENV['RAILS_GROUPS'] == 'assets' || self.log_silently == false
+      ENV['RAILS_GROUPS'] == 'assets' || !!self.log_silently
     end
 
     def enabled?

--- a/spec/unit/asset_sync_spec.rb
+++ b/spec/unit/asset_sync_spec.rb
@@ -65,6 +65,17 @@ describe AssetSync do
     it "should default log_silently to true" do
       expect(AssetSync.config.log_silently).to be_truthy
     end
+    
+    it "log_silently? should reflect the configuration" do
+      AssetSync.config.log_silently = false
+      expect(AssetSync.config.log_silently?).to eq(false)
+    end
+
+    it "log_silently? should always be true if ENV['RAILS_GROUPS'] == 'assets'" do
+      AssetSync.config.log_silently = false
+      expect(ENV).to receive(:[]).with('RAILS_GROUPS').and_return('assets')
+      expect(AssetSync.config.log_silently?).to eq(true)
+    end
 
     it "should default cdn_distribution_id to nil" do
       expect(AssetSync.config.cdn_distribution_id).to be_nil

--- a/spec/unit/asset_sync_spec.rb
+++ b/spec/unit/asset_sync_spec.rb
@@ -73,7 +73,8 @@ describe AssetSync do
 
     it "log_silently? should always be true if ENV['RAILS_GROUPS'] == 'assets'" do
       AssetSync.config.log_silently = false
-      expect(ENV).to receive(:[]).with('RAILS_GROUPS').and_return('assets')
+      # make sure ENV is actually being checked ...
+      expect(ENV).to receive(:[]).with('RAILS_GROUPS').and_return('assets') 
       expect(AssetSync.config.log_silently?).to eq(true)
     end
 


### PR DESCRIPTION
`log_silently?` would almost always return true, now it honors the config value unless the `RAILS_GROUPS` env var is set to `assets`.