### PR TITLE
Limit number of runtime dependencies for fog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,10 @@ gem 'asset_sync'
 
 ### Optimized Fog loading
 
-Since AssetSync doesn't know which parts of Fog you intend to use, it will just load the entire library.
-If you prefer to load fewer classes into your application, which will reduce load time and memory use,
-you need to load those parts of Fog yourself *before* loading AssetSync:
-
-In your Gemfile:
+Since AssetSync doesn't know which parts of Fog you intend to use, it will just load the fog-core library.
+In order to use aws or other providers, add those in your Gemfile accordingly, like:
 ```ruby
-gem "fog", "~>1.20", require: "fog/aws/storage"
+gem "fog-aws"
 gem "asset_sync"
 ```
 

--- a/asset_sync.gemspec
+++ b/asset_sync.gemspec
@@ -18,11 +18,12 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "asset_sync"
 
-  s.add_dependency('fog', ">= 1.8.0")
+  s.add_dependency('fog-core', ">= 1.8.0")
   s.add_dependency('unf')
   s.add_dependency('activemodel')
 
   s.add_development_dependency "rspec"
+  s.add_development_dependency "fog-aws"
   s.add_development_dependency "bundler"
   s.add_development_dependency "jeweler"
 

--- a/lib/asset_sync.rb
+++ b/lib/asset_sync.rb
@@ -1,4 +1,4 @@
-require 'fog' unless defined?(::Fog)
+require 'fog/core'
 require 'active_model'
 require 'erb'
 require "asset_sync/asset_sync"
@@ -7,5 +7,7 @@ require 'asset_sync/storage'
 require 'asset_sync/multi_mime'
 
 
-require 'asset_sync/railtie' if defined?(Rails)
-require 'asset_sync/engine'  if defined?(Rails)
+if defined?(Rails)
+  require 'asset_sync/railtie'
+  require 'asset_sync/engine'
+end

--- a/spec/integration/aws_integration_spec.rb
+++ b/spec/integration/aws_integration_spec.rb
@@ -1,5 +1,7 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
+require "fog/aws"
+
 def bucket(name)
   options = {
     :provider => 'AWS',
@@ -23,12 +25,12 @@ describe "AssetSync" do
     @prefix = SecureRandom.hex(6)
   end
 
-  let(:app_js_regex){ 
-    /#{@prefix}\/application-[a-zA-Z0-9]*.js$/ 
+  let(:app_js_regex){
+    /#{@prefix}\/application-[a-zA-Z0-9]*.js$/
   }
 
-  let(:app_js_gz_regex){ 
-    /#{@prefix}\/application-[a-zA-Z0-9]*.js.gz$/ 
+  let(:app_js_gz_regex){
+    /#{@prefix}\/application-[a-zA-Z0-9]*.js.gz$/
   }
 
   let(:files){ bucket(@prefix).files }


### PR DESCRIPTION
By default fog depends on all possible fog providers, which boosts unnecessary number of dependencies.

`fog-core` on the other hand, have minimum amount of deps, and mimimum number of classes, which leaves developer more space by using only required provider. 

This commit reduces number of dependencies from 94 to 64.
