### PR TITLE
! Add missing runtime dependency declaration to gemspec

### DIFF
--- a/asset_sync.gemspec
+++ b/asset_sync.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('fog', ">= 1.8.0")
   s.add_dependency('unf')
   s.add_dependency('activemodel')
+  s.add_dependency('mime-types')
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "bundler"


### PR DESCRIPTION
This adds `mime-types` as runtime dependency into gemspec
Which is required in `https://github.com/AssetSync/asset_sync/blob/master/lib/asset_sync/multi_mime.rb`

Currently it's indirectly included by `actionmailer` => `mail` => `mime-types`