### PR TITLE
Fix/config log sliently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Nothing
+- Respect value of option `log_silently` even when `ENV['RAILS_GROUPS'] == 'assets'`
 
 
 ## [1.2.0] - 2016-08-17

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ AssetSync.configure do |config|
   #
   # Fail silently.  Useful for environments such as Heroku
   # config.fail_silently = true
+  #
+  # Log silently. Default is `true`. But you can set it to false if more logging message are preferred.
+  # Logging messages are sent to `STDOUT` when `log_silently` is falsy
+  # config.log_silently = true
 end
 ```
 

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -95,7 +95,7 @@ module AssetSync
     end
 
     def log_silently?
-      ENV['RAILS_GROUPS'] == 'assets' || !!self.log_silently
+      !!self.log_silently
     end
 
     def enabled?

--- a/spec/unit/asset_sync_spec.rb
+++ b/spec/unit/asset_sync_spec.rb
@@ -70,7 +70,7 @@ describe AssetSync do
     it "should default log_silently to true" do
       expect(AssetSync.config.log_silently).to be_truthy
     end
-    
+
     it "log_silently? should reflect the configuration" do
       AssetSync.config.log_silently = false
       expect(AssetSync.config.log_silently?).to eq(false)
@@ -78,9 +78,9 @@ describe AssetSync do
 
     it "log_silently? should always be true if ENV['RAILS_GROUPS'] == 'assets'" do
       AssetSync.config.log_silently = false
-      # make sure ENV is actually being checked ...
-      expect(ENV).to receive(:[]).with('RAILS_GROUPS').and_return('assets') 
-      expect(AssetSync.config.log_silently?).to eq(true)
+      allow(ENV).to receive(:[]).with('RAILS_GROUPS').and_return('assets')
+
+      expect(AssetSync.config.log_silently?).to eq(false)
     end
 
     it "should default cdn_distribution_id to nil" do


### PR DESCRIPTION
In ancient time
noahhaon@14fed3a
The code was `STDERR.puts msg if ENV["RAILS_GROUPS"] == "assets"`
But this conditional statement was kept for backward compatibility (or by mistake)

With this conditional statement, the option becomes useless when the condition is true