### PR TITLE
Add method add_local_file_paths to config class

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -67,6 +67,8 @@ module AssetSync
       self.cdn_distribution_id = nil
       self.invalidate = []
       self.cache_asset_regexps = []
+      @additional_local_file_paths_procs = []
+
       load_yml! if defined?(::Rails) && yml_exists?
     end
 
@@ -220,7 +222,29 @@ module AssetSync
       return options
     end
 
+    # @api
+    def add_local_file_paths(&block)
+      @additional_local_file_paths_procs =
+        additional_local_file_paths_procs + [block]
+    end
+
+    # @api private
+    #   This is to be called in Storage
+    #   Not to be called by user
+    def additional_local_file_paths
+      return [] if additional_local_file_paths_procs.empty?
+
+      # Using `Array()` to ensure it works when single value is returned
+      additional_local_file_paths_procs.each_with_object([]) do |proc, paths|
+        paths.concat(Array(proc.call))
+      end
+    end
+
   private
+
+    # This is a proc to get additional local files paths
+    # Since this is a proc it won't be able to be configured by a YAML file
+    attr_reader :additional_local_file_paths_procs
 
     def default_manifest_directory
       File.join(::Rails.public_path, assets_prefix)

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -42,7 +42,8 @@ module AssetSync
     end
 
     def local_files
-      @local_files ||= get_local_files.uniq
+      @local_files ||=
+        (get_local_files + config.additional_local_file_paths).uniq
     end
 
     def always_upload_files

--- a/spec/unit/storage_spec.rb
+++ b/spec/unit/storage_spec.rb
@@ -13,7 +13,7 @@ describe AssetSync::Storage do
     it 'should overwrite all remote files if set to ignore' do
       @config.existing_remote_files = 'ignore'
       storage = AssetSync::Storage.new(@config)
-      allow(storage).to receive(:local_files).and_return(@local_files)
+      allow(storage).to receive(:get_local_files).and_return(@local_files)
       allow(File).to receive(:file?).and_return(true) # Pretend they all exist
 
       @local_files.each do |file|
@@ -26,7 +26,7 @@ describe AssetSync::Storage do
       @config.always_upload = ['local_image.jpg', /local_image\d\.svg/]
 
       storage = AssetSync::Storage.new(@config)
-      allow(storage).to receive(:local_files).and_return(@local_files)
+      allow(storage).to receive(:get_local_files).and_return(@local_files)
       allow(storage).to receive(:get_remote_files).and_return(@remote_files)
       allow(File).to receive(:file?).and_return(true) # Pretend they all exist
 
@@ -40,7 +40,7 @@ describe AssetSync::Storage do
       @config.ignored_files = ['local_image1.jpg', /local_stylesheet\d\.css/]
 
       storage = AssetSync::Storage.new(@config)
-      allow(storage).to receive(:local_files).and_return(@local_files)
+      allow(storage).to receive(:get_local_files).and_return(@local_files)
       allow(storage).to receive(:get_remote_files).and_return(@remote_files)
       allow(File).to receive(:file?).and_return(true) # Pretend they all exist
 
@@ -68,7 +68,78 @@ describe AssetSync::Storage do
       ]
 
       storage = AssetSync::Storage.new(@config)
-      allow(storage).to receive(:local_files).and_return(@local_files)
+      allow(storage).to receive(:get_local_files).and_return(@local_files)
+      allow(storage).to receive(:get_remote_files).and_return(@remote_files)
+      allow(File).to receive(:file?).and_return(true) # Pretend they all exist
+
+      updated_nonfingerprinted_files = [
+        'public/image.png',
+        'public/application.js',
+      ]
+      (@local_files - @remote_files + updated_nonfingerprinted_files).each do |file|
+        expect(storage).to receive(:upload_file).with(file)
+      end
+      storage.upload_files
+    end
+
+    context "when config #add_local_file_paths is called" do
+      let(:additional_local_file_paths) do
+        ["webpack/example_asset.jpg"]
+      end
+
+      before(:each) do
+        @config.add_local_file_paths do
+          additional_local_file_paths
+        end
+      end
+
+      let(:storage) do
+        AssetSync::Storage.new(@config)
+      end
+
+      let(:file_paths_should_be_uploaded) do
+        @local_files -
+          @remote_files -
+          storage.ignored_files +
+          storage.always_upload_files +
+          additional_local_file_paths
+      end
+
+      before do
+        # Stubbing
+        allow(storage).to receive(:get_local_files).and_return(@local_files)
+        allow(storage).to receive(:get_remote_files).and_return(@remote_files)
+        # Pretend the files all exist
+        allow(File).to receive(:file?).and_return(true)
+      end
+
+      it "uploads additional files in additional to local files" do
+        file_paths_should_be_uploaded.each do |file|
+          expect(storage).to receive(:upload_file).with(file)
+        end
+        storage.upload_files
+      end
+    end
+
+    it 'should upload additonal  files' do
+      @local_files = [
+        'public/image.png',
+        'public/image-82389298328.png',
+        'public/image-a8389f9h324.png',
+        'public/application.js',
+        'public/application-b3389d983k1.js',
+        'public/application-ac387d53f31.js',
+        'public',
+      ]
+      @remote_files = [
+        'public/image.png',
+        'public/image-a8389f9h324.png',
+        'public/application.js',
+        'public/application-b3389d983k1.js',
+      ]
+
+      storage = AssetSync::Storage.new(@config)
+      allow(storage).to receive(:get_local_files).and_return(@local_files)
       allow(storage).to receive(:get_remote_files).and_return(@remote_files)
       allow(File).to receive(:file?).and_return(true) # Pretend they all exist
 
@@ -110,7 +181,7 @@ describe AssetSync::Storage do
       remote_files = []
       @config.cache_asset_regexps = [/\.[a-f0-9]{6}$/i, /\.[a-f0-9]{8}$/i]
       storage = AssetSync::Storage.new(@config)
-      allow(storage).to receive(:local_files).and_return(local_files)
+      allow(storage).to receive(:get_local_files).and_return(local_files)
       allow(storage).to receive(:get_remote_files).and_return(remote_files)
       allow(File).to receive(:file?).and_return(true)
       allow(File).to receive(:open).and_return(nil)
@@ -155,7 +226,7 @@ describe AssetSync::Storage do
       @config.fog_provider = 'AWS'
 
       storage = AssetSync::Storage.new(@config)
-      allow(storage).to receive(:local_files).and_return(@local_files)
+      allow(storage).to receive(:get_local_files).and_return(@local_files)
       allow(storage).to receive(:get_remote_files).and_return(@remote_files)
       allow(storage).to receive(:upload_file).and_return(true)
 
@@ -193,7 +264,7 @@ describe AssetSync::Storage do
         }
       }
       storage = AssetSync::Storage.new(@config)
-      allow(storage).to receive(:local_files).and_return(@local_files)
+      allow(storage).to receive(:get_local_files).and_return(@local_files)
       allow(storage).to receive(:get_remote_files).and_return(@remote_files)
       allow(File).to receive(:open).and_return('file') # Pretend they all exist
 
@@ -216,7 +287,7 @@ describe AssetSync::Storage do
         }
       }
       storage = AssetSync::Storage.new(@config)
-      allow(storage).to receive(:local_files).and_return(@local_files)
+      allow(storage).to receive(:get_local_files).and_return(@local_files)
       allow(storage).to receive(:get_remote_files).and_return(@remote_files)
       allow(File).to receive(:open).and_return('file') # Pretend they all exist
       bucket = double


### PR DESCRIPTION
Alternative to #346 
Allows multiple list of local file paths to be added

Usage: (in Ruby code)
```ruby
AssetSync.configure do |config|
  # The block should return an array of file paths
  config.add_local_file_paths do
    # Any code that returns paths of local asset files to be uploaded
    # Like Webpacker
    Dir[File.join(Webpacker::Configuration.fetch(:public_output_path), '/**/**')]
  end
end
```

This new method does **not** affect existing options
The existing list of local files generated is still the same
Using this new method only add new file paths

Also replaces
- #345
- #341

Fixes #344