### PR TITLE
Check all library for mime type lookup

### DIFF
--- a/lib/asset_sync/multi_mime.rb
+++ b/lib/asset_sync/multi_mime.rb
@@ -5,16 +5,27 @@ module AssetSync
 
     def self.lookup(ext)
 
+      mime = nil
+      library_found = false
       if defined?(::MIME::Types)
-        ::MIME::Types.type_for(ext).first
-      elsif defined?(::Mime::Type)
-        ::Mime::Type.lookup_by_extension(ext)
-      elsif defined?(::Rack::Mime)
+        mime = ::MIME::Types.type_for(ext).first
+        library_found = true
+      end
+      if !mime && defined?(::Mime::Type)
+        mime = ::Mime::Type.lookup_by_extension(ext)
+        library_found = true
+      end
+      if !mime && defined?(::Rack::Mime)
         ext_with_dot = ".#{ext}"
-        ::Rack::Mime.mime_type(ext_with_dot)
-      else
+        mime = ::Rack::Mime.mime_type(ext_with_dot)
+        library_found = true
+      end
+
+      if !library_found
         raise "No library found for mime type lookup"
       end
+
+      mime
 
     end
 


### PR DESCRIPTION
In some environments, lookup of mime type fails with one library, but succeeds with another library.
For instance, in my Rails app, lookup of `'svg'` only succeeds when `::Rack::Mime` is used.

```ruby
[1] pry(main)> ext = "svg"
=> "svg"
[3] pry(main)> defined?(::Mime::Types)
=> nil
[2] pry(main)> ::Mime::Type.lookup_by_extension(ext)
=> nil
[4] pry(main)> ::Rack::Mime.mime_type(".#{ext}")
=> "image/svg+xml"
```

I think we should check all libraries until lookup succeeds.
This patch will introduce all libraries checking.

Related to https://github.com/AssetSync/asset_sync/pull/322 https://github.com/AssetSync/asset_sync/issues/323

