### PR TITLE
Fix doc example for Webpacker

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ AssetSync.configure do |config|
     # Any code that returns paths of local asset files to be uploaded
     # Like Webpacker
     Dir.chdir(Rails.root.join('public')) do
-      Dir[File.join(Webpacker::Configuration.fetch(:public_output_path), '/**/**')]
+      Dir[File.join(Webpacker.config.public_output_path, '/**/**')]
     end
   end
 end


### PR DESCRIPTION
`Webpacker::Configuration` no longer has a class method `fetch`.