### PR TITLE
Allow 20+ chars length hash digest

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -5,7 +5,7 @@ require "asset_sync/multi_mime"
 module AssetSync
   class Storage
     REGEXP_FINGERPRINTED_FILES = /^(.*)\/([^-]+)-[^\.]+\.([^\.]+)$/
-    REGEXP_ASSETS_TO_CACHE_CONTROL = /-[0-9a-fA-F]{32,}$/
+    REGEXP_ASSETS_TO_CACHE_CONTROL = /-[0-9a-fA-F]{20,}$/
 
     class BucketNotFound < StandardError;
     end


### PR DESCRIPTION
Default webpacker configuration output js bundled files with a 20 chars length hash. It took me a little bit of time to figure out why only JS files would not get a proper cache_control header...