### PR TITLE
Always return mimetype as string

### DIFF
--- a/lib/asset_sync/multi_mime.rb
+++ b/lib/asset_sync/multi_mime.rb
@@ -11,9 +11,9 @@ module AssetSync
       end
 
       if defined?(::MIME::Types)
-        ::MIME::Types.type_for(ext).first
+        ::MIME::Types.type_for(ext).first.to_s
       elsif defined?(::Mime::Type)
-        ::Mime::Type.lookup_by_extension(ext)
+        ::Mime::Type.lookup_by_extension(ext).to_s
       elsif defined?(::Rack::Mime)
         ext_with_dot = ".#{ext}"
         ::Rack::Mime.mime_type(ext_with_dot)

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -231,12 +231,6 @@ module AssetSync
         })
       end
 
-      if config.azure_rm?
-        # converts content_type from MIME::Type to String.
-        # because Azure::Storage (called from Fog::AzureRM) expects content_type as a String like "application/json; charset=utf-8"
-        file[:content_type] = file[:content_type].content_type if file[:content_type].is_a?(::MIME::Type)
-      end
-
       bucket.files.create( file ) unless ignore
       file_handle.close
       gzip_file_handle.close if gzip_file_handle


### PR DESCRIPTION
Currently MultiMime.lookup returns either 
::MIME::Type if it uses MIME::Types or ::Mime::Type
and returns a string containing the content type
if it uses ::Rack::Mime. This change makes the 
return type consistently a string, which is AFAICT
supported by all fog-providers. 

This change also allows us to remove the unnecessary 
type checking of the content-type in storage.rb as 
we can be assured its a string. Something similar will need to 
be done to support the JSON storage API with fog-google 
so this is prep work

Tests still pass and have always been testing for strings anyway
