### PR TITLE
Adds JSON API support when using Google Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you wish to have your assets sync to a sub-folder of your bucket instead of i
 ```ruby
   # store assets in a 'folder' instead of bucket root
   config.assets.prefix = "/production/assets"
-````
+​````
 
 Also, ensure the following are defined (in production.rb or application.rb)
 
@@ -141,7 +141,7 @@ The Built-in Initializer will configure **AssetSync** based on the contents of y
 
 Add your configuration details to **heroku**
 
-``` bash
+​``` bash
 heroku config:add AWS_ACCESS_KEY_ID=xxxx
 heroku config:add AWS_SECRET_ACCESS_KEY=xxxx
 heroku config:add FOG_DIRECTORY=xxxx
@@ -170,7 +170,17 @@ heroku config:add FOG_DIRECTORY=xxxx
 heroku config:add FOG_PROVIDER=Rackspace
 ```
 
-Google Storage Cloud configuration is supported as well
+Google Storage Cloud configuration is supported as well. The preferred option is using the [GCS JSON API](https://github.com/fog/fog-google#storage) which requires that you create an appropriate service account, generate the signatures and make them accessible to asset sync at the prescribed location 
+
+```bash
+heroku config:add FOG_PROVIDER=Google
+heroku config:add GOOGLE_PROJECT=xxxx
+heroku config:add GOOGLE_JSON_KEY_LOCATION=xxxx
+heroku config:add FOG_DIRECTORY=xxxx
+```
+
+If using the S3 API the following config is required
+
 ``` bash
 heroku config:add FOG_PROVIDER=Google
 heroku config:add GOOGLE_STORAGE_ACCESS_KEY_ID=xxxx
@@ -385,6 +395,14 @@ The blocks are run when local files are being scanned and uploaded
 * **rackspace\_api\_key**: your Rackspace API Key.
 
 #### Google Storage
+
+When using the JSON API
+
+- **google\_project**: your Google Cloud Project name where the Google Cloud Storage bucket resides
+- **google\_json\_key\_location**: path to the location of the service account key.  The service account key must be a JSON type key
+
+When using the S3 API
+
 * **google\_storage\_access\_key\_id**: your Google Storage access key
 * **google\_storage\_secret\_access\_key**: your Google Storage access secret
 
@@ -584,7 +602,7 @@ Make sure you have a .env file with these details:-
     AWS_SECRET_ACCESS_KEY=<yoursecretkey>
     FOG_DIRECTORY=<yourbucket>
     FOG_REGION=<youbucketregion>
-
+    
     # for AzureRM provider
     AZURE_STORAGE_ACCOUNT_NAME=<youraccountname>
     AZURE_STORAGE_ACCESS_KEY=<youraccesskey>

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -44,7 +44,9 @@ module AssetSync
     attr_accessor :rackspace_username, :rackspace_api_key, :rackspace_auth_url
 
     # Google Storage
-    attr_accessor :google_storage_secret_access_key, :google_storage_access_key_id
+    attr_accessor :google_storage_secret_access_key, :google_storage_access_key_id  # when using S3 interop
+    attr_accessor :google_json_key_location # when using service accounts
+    attr_accessor :google_project # when using service accounts
 
     # Azure Blob with Fog::AzureRM
     attr_accessor :azure_storage_account_name
@@ -59,8 +61,10 @@ module AssetSync
     validates :aws_secret_access_key, :presence => true, :if => proc {aws? && !aws_iam?}
     validates :rackspace_username,    :presence => true, :if => :rackspace?
     validates :rackspace_api_key,     :presence => true, :if => :rackspace?
-    validates :google_storage_secret_access_key,  :presence => true, :if => :google?
-    validates :google_storage_access_key_id,      :presence => true, :if => :google?
+    validates :google_storage_secret_access_key,  :presence => true, :if => :google_interop?
+    validates :google_storage_access_key_id,      :presence => true, :if => :google_interop?
+    validates :google_json_key_location,          :presence => true, :if => :google_service_account?
+    validates :google_project,                    :presence => true, :if => :google_service_account?
 
     def initialize
       self.fog_region = nil
@@ -130,6 +134,14 @@ module AssetSync
       fog_provider =~ /google/i
     end
 
+    def google_interop?
+      google? && google_json_key_location.nil?
+    end
+
+    def google_service_account?
+      google? && google_json_key_location
+    end
+
     def azure_rm?
       fog_provider =~ /azurerm/i
     end
@@ -176,8 +188,10 @@ module AssetSync
       self.rackspace_username     = yml["rackspace_username"]
       self.rackspace_auth_url     = yml["rackspace_auth_url"] if yml.has_key?("rackspace_auth_url")
       self.rackspace_api_key      = yml["rackspace_api_key"]
-      self.google_storage_secret_access_key = yml["google_storage_secret_access_key"]
-      self.google_storage_access_key_id     = yml["google_storage_access_key_id"]
+      self.google_json_key_location = yml["google_json_key_location"] if yml.has_key?("google_json_key_location")
+      self.google_project = yml["google_project"] if yml.has_key?("google_project")
+      self.google_storage_secret_access_key = yml["google_storage_secret_access_key"] if yml.has_key?("google_storage_secret_access_key")
+      self.google_storage_access_key_id     = yml["google_storage_access_key_id"] if yml.has_key?("google_storage_access_key_id")
       self.existing_remote_files  = yml["existing_remote_files"] if yml.has_key?("existing_remote_files")
       self.gzip_compression       = yml["gzip_compression"] if yml.has_key?("gzip_compression")
       self.manifest               = yml["manifest"] if yml.has_key?("manifest")
@@ -236,10 +250,14 @@ module AssetSync
         options.merge!({ :rackspace_region => fog_region }) if fog_region
         options.merge!({ :rackspace_auth_url => rackspace_auth_url }) if rackspace_auth_url
       elsif google?
-        options.merge!({
-          :google_storage_secret_access_key => google_storage_secret_access_key,
-          :google_storage_access_key_id => google_storage_access_key_id
-        })
+        if google_json_key_location
+          options.merge!({:google_json_key_location => google_json_key_location, :google_project => google_project})
+        else
+          options.merge!({
+            :google_storage_secret_access_key => google_storage_secret_access_key,
+            :google_storage_access_key_id => google_storage_access_key_id
+          })
+        end
         options.merge!({:region => fog_region}) if fog_region
       elsif azure_rm?
         require 'fog/azurerm'

--- a/spec/fixtures/google_with_service_account_yml/config/asset_sync.yml
+++ b/spec/fixtures/google_with_service_account_yml/config/asset_sync.yml
@@ -1,0 +1,19 @@
+defaults: &defaults
+  fog_provider: "Google"
+  google_json_key_location: 'gcs.json'
+  google_project: 'some-project'
+
+development:
+  <<: *defaults
+  fog_directory: "rails_app_development"
+  existing_remote_files: keep
+
+test:
+  <<: *defaults
+  fog_directory: "rails_app_test"
+  existing_remote_files: keep
+
+production:
+  <<: *defaults
+  fog_directory: "rails_app_production"
+  existing_remote_files: delete


### PR DESCRIPTION
The current Google Storage support requires the
use of the S3 compatible API on GCS which is
slower and not leveraging service accounts.
The underlying library Fog Google does support
the ability to use Google Storage JSON API
(https://github.com/fog/fog-google#storage)

This change adds support for the setting of the
relevant config options and passes these config
options to Fog Google so that we can use service
accounts.