### PR TITLE
Include fog port in AWS configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ AssetSync.configure do |config|
   # Change host option in fog (only if you need to)
   # config.fog_host = 's3.amazonaws.com'
   #
+  # Change port option in fog (only if you need to)
+  # config.fog_port = "9000"
+  #
   # Use http instead of https.
   # config.fog_scheme = 'http'
   #

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -37,6 +37,7 @@ module AssetSync
     # Amazon AWS
     attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_reduced_redundancy, :aws_iam_roles, :aws_signature_version
     attr_accessor :fog_host              # e.g. 's3.amazonaws.com'
+    attr_accessor :fog_port              # e.g. '9000'
     attr_accessor :fog_path_style        # e.g. true
     attr_accessor :fog_scheme            # e.g. 'http'
 
@@ -175,6 +176,7 @@ module AssetSync
       self.enabled                = yml["enabled"] if yml.has_key?('enabled')
       self.fog_provider           = yml["fog_provider"]
       self.fog_host               = yml["fog_host"]
+      self.fog_port               = yml["fog_port"]
       self.fog_directory          = yml["fog_directory"]
       self.fog_region             = yml["fog_region"]
       self.fog_public             = yml["fog_public"] if yml.has_key?("fog_public")
@@ -238,6 +240,7 @@ module AssetSync
           })
         end
         options.merge!({:host => fog_host}) if fog_host
+        options.merge!({:port => fog_port}) if fog_port
         options.merge!({:scheme => fog_scheme}) if fog_scheme
         options.merge!({:aws_signature_version => aws_signature_version}) if aws_signature_version
         options.merge!({:path_style => fog_path_style}) if fog_path_style

--- a/lib/asset_sync/engine.rb
+++ b/lib/asset_sync/engine.rb
@@ -17,6 +17,7 @@ module AssetSync
           config.fog_directory = ENV['FOG_DIRECTORY'] if ENV.has_key?('FOG_DIRECTORY')
           config.fog_region = ENV['FOG_REGION'] if ENV.has_key?('FOG_REGION')
           config.fog_host = ENV['FOG_HOST'] if ENV.has_key?('FOG_HOST')
+          config.fog_port = ENV['FOG_PORT'] if ENV.has_key?('FOG_PORT')
           config.fog_scheme = ENV['FOG_SCHEMA'] if ENV.has_key?('FOG_SCHEMA')
           config.fog_path_style = ENV['FOG_PATH_STYLE'] if ENV.has_key?('FOG_PATH_STYLE')
 

--- a/lib/generators/asset_sync/templates/asset_sync.rb
+++ b/lib/generators/asset_sync/templates/asset_sync.rb
@@ -13,6 +13,9 @@ if defined?(AssetSync)
     # Change host option in fog (only if you need to)
     # config.fog_host = "s3.amazonaws.com"
     #
+    # Change port option in fog (only if you need to)
+    # config.fog_port = "9000"
+    #
     # Use http instead of https. Default should be "https" (at least for fog-aws)
     # config.fog_scheme = "http"
     <%- elsif google? -%>

--- a/lib/generators/asset_sync/templates/asset_sync.yml
+++ b/lib/generators/asset_sync/templates/asset_sync.yml
@@ -13,6 +13,9 @@ defaults: &defaults
   # Change host option in fog (only if you need to)
   # fog_host: "s3.amazonaws.com"
   #
+  # Change port option in fog (only if you need to)
+  # config.fog_port = "9000"
+  #
   # Use http instead of https. Default should be "https" (at least for fog-aws)
   # fog_scheme: "http"
   <%- elsif google? -%>


### PR DESCRIPTION
Fog [allows a port](https://github.com/fog/fog-aws/blob/d84473bbd129e469309f9938b860c51b06feea99/lib/fog/aws/storage.rb#L46) to be set for the connection with AWS.

I'm using [minio](https://github.com/minio/minio) which implements the S3 API, and runs on port 9000. That's where allowing the port to be configured might come in handy.