### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/asset_sync.gemspec
+++ b/asset_sync.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.rubyforge_project = "asset_sync"
-
   s.add_dependency("fog-core")
   s.add_dependency('unf')
   s.add_dependency('activemodel', ">= 4.1.0")


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.