### PR TITLE
Fix FogPublicValue#to_bool

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -361,7 +361,7 @@ module AssetSync
       end
 
       def to_bool
-        !@value.nil?
+        !!@value
       end
     end
   end

--- a/spec/unit/asset_sync_spec.rb
+++ b/spec/unit/asset_sync_spec.rb
@@ -283,4 +283,16 @@ describe AssetSync do
       expect{ AssetSync::Config.new }.to raise_error(Psych::SyntaxError)
     end
   end
+
+  describe 'FogPublicValue' do
+    it "true should be converted to true" do
+      expect(AssetSync::Config::FogPublicValue.new(true).to_bool).to be_truthy
+    end
+    it "false should be converted to false" do
+      expect(AssetSync::Config::FogPublicValue.new(false).to_bool).to be_falsey
+    end
+    it "nil should be converted to false" do
+      expect(AssetSync::Config::FogPublicValue.new(nil).to_bool).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
Hi, I found a bug when converting to a boolean value with FogPublicValue.

In documentation, 

```
# Possible values: true, false, "default" (default: true)
# config.fog_public = true
```

but, If `false` is set, `to_bool` method returns `true`
The following is a reproduction ...

```
% cat Gemfile
source "https://rubygems.org"
gem "asset_sync"
% cat main.rb
require 'asset_sync'

false_value = AssetSync::Config::FogPublicValue.new(false)
nil_value = AssetSync::Config::FogPublicValue.new(nil)
true_value = AssetSync::Config::FogPublicValue.new(true)

p false_value.to_bool
p nil_value.to_bool
p true_value.to_bool
% bundle exec ruby main.rb
true
false
true
```

I fixed it.
