### PR TITLE
Support AWS temporary credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ AssetSync.configure do |config|
   config.fog_directory = ENV['FOG_DIRECTORY']
   config.aws_access_key_id = ENV['AWS_ACCESS_KEY_ID']
   config.aws_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
+  config.aws_session_token = ENV['AWS_SESSION_TOKEN'] if ENV.key?['AWS_SESSION_TOKEN']
 
   # Don't delete files from the store
   # config.existing_remote_files = 'keep'

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -37,7 +37,7 @@ module AssetSync
     attr_reader   :fog_public            # e.g. true, false, "default"
 
     # Amazon AWS
-    attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_reduced_redundancy, :aws_iam_roles, :aws_signature_version
+    attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_session_token, :aws_reduced_redundancy, :aws_iam_roles, :aws_signature_version
     attr_accessor :fog_host              # e.g. 's3.amazonaws.com'
     attr_accessor :fog_port              # e.g. '9000'
     attr_accessor :fog_path_style        # e.g. true
@@ -203,6 +203,7 @@ module AssetSync
       self.fog_scheme             = yml["fog_scheme"]
       self.aws_access_key_id      = yml["aws_access_key_id"]
       self.aws_secret_access_key  = yml["aws_secret_access_key"]
+      self.aws_session_token      = yml["aws_session_token"] if yml.has_key?("aws_session_token")
       self.aws_reduced_redundancy = yml["aws_reduced_redundancy"]
       self.aws_iam_roles          = yml["aws_iam_roles"]
       self.aws_signature_version  = yml["aws_signature_version"]
@@ -260,6 +261,7 @@ module AssetSync
             :aws_access_key_id => aws_access_key_id,
             :aws_secret_access_key => aws_secret_access_key
           })
+          options.merge!({:aws_session_token => aws_session_token}) if aws_session_token
         end
         options.merge!({:host => fog_host}) if fog_host
         options.merge!({:port => fog_port}) if fog_port

--- a/lib/asset_sync/engine.rb
+++ b/lib/asset_sync/engine.rb
@@ -23,6 +23,7 @@ module AssetSync
 
           config.aws_access_key_id = ENV['AWS_ACCESS_KEY_ID'] if ENV.has_key?('AWS_ACCESS_KEY_ID')
           config.aws_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY'] if ENV.has_key?('AWS_SECRET_ACCESS_KEY')
+          config.aws_session_token = ENV['AWS_SESSION_TOKEN'] if ENV.has_key?('AWS_SESSION_TOKEN')
           config.aws_signature_version = ENV['AWS_SIGNATURE_VERSION'] if ENV.has_key?('AWS_SIGNATURE_VERSION')
           config.aws_reduced_redundancy = ENV['AWS_REDUCED_REDUNDANCY'] == true  if ENV.has_key?('AWS_REDUCED_REDUNDANCY')
 

--- a/lib/generators/asset_sync/install_generator.rb
+++ b/lib/generators/asset_sync/install_generator.rb
@@ -35,6 +35,10 @@ module AssetSync
       "<%= ENV['AWS_SECRET_ACCESS_KEY'] %>"
     end
 
+    def aws_session_token
+      "<%= ENV['AWS_SESSION_TOKEN'] %>"
+    end
+
     def google_storage_access_key_id
       "<%= ENV['GOOGLE_STORAGE_ACCESS_KEY_ID'] %>"
     end

--- a/lib/generators/asset_sync/templates/asset_sync.rb
+++ b/lib/generators/asset_sync/templates/asset_sync.rb
@@ -4,6 +4,7 @@ if defined?(AssetSync)
     config.fog_provider = 'AWS'
     config.aws_access_key_id = ENV['AWS_ACCESS_KEY_ID']
     config.aws_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
+    config.aws_session_token = ENV['AWS_SESSION_TOKEN'] if ENV.key?['AWS_SESSION_TOKEN']
     # To use AWS reduced redundancy storage.
     # config.aws_reduced_redundancy = true
     #


### PR DESCRIPTION
When you run asset_sync locally with tools like [`aws-vault`](https://github.com/99designs/aws-vault) they will get temporary credentials from AWS STS service and set [`AWS_SESSION_TOKEN `](https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-aws_session_token.html)

This PR adds support for temporary credentials.