### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 language: ruby
+arch: 
+  - amd64
+  - ppc64le
 cache:
   bundler: true
 rvm:


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) . Detecting (and fixing) any issues 
or failures early would help to ensure that we are always up to date.