### PR TITLE
* Create GitHub Workflow config to simulate Travis builds

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,59 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+
+jobs:
+  unit_tests:
+    name: Unit Tests
+    if: "contains(github.event.commits[0].message, '[ci skip]') == false"
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu
+        ruby:
+          - 2.5
+          - 2.6
+          - 2.7
+          # Disabled due to `bundle install` timeout
+          # Same for `jruby-head` below
+          # - jruby
+        gemfile:
+          - gemfiles/rails_5_2.gemfile
+          - gemfiles/rails_6_0.gemfile
+        allow_failures:
+          - false
+        include:
+          - os: ubuntu
+            ruby: ruby-head
+            gemfile: gemfiles/rails_6_0.gemfile
+            allow_failures: true
+#          - os: ubuntu
+#            ruby: jruby-head
+#            gemfile: gemfiles/rails_6_0.gemfile
+#            allow_failures: true
+    env:
+      BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
+      ALLOW_FAILURES: "${{ matrix.allow_failures }}"
+    runs-on: ${{ matrix.os }}-latest
+    continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Test
+        run: bundle exec rake spec:unit || $ALLOW_FAILURES


### PR DESCRIPTION
Copied from TravisCI config
Removed EOL Ruby & Rails versions
Commented out JRuby due to [`bundle install` timeout](https://github.com/AssetSync/asset_sync/actions/runs/420385942)
No `ppc64le` support yet
No integration test (due to the encrypted env vars, I don't have the non-encrypted values to [setup secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets))