### PR TITLE
Fix get_non_fingerprinted with dashed filenames

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -4,7 +4,7 @@ require "asset_sync/multi_mime"
 
 module AssetSync
   class Storage
-    REGEXP_FINGERPRINTED_FILES = /\A(.*)\/(.+)-[^\.]+\.([^\.]+)\z/
+    REGEXP_FINGERPRINTED_FILES = /\A(.*)\/(.+)-[^\.]+\.([^\.]+)\z/m
     REGEXP_ASSETS_TO_CACHE_CONTROL = /-[0-9a-fA-F]{32,}$/
 
     class BucketNotFound < StandardError;

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -4,7 +4,7 @@ require "asset_sync/multi_mime"
 
 module AssetSync
   class Storage
-    REGEXP_FINGERPRINTED_FILES = /^(.*)\/([^-]+)-[^\.]+\.([^\.]+)$/
+    REGEXP_FINGERPRINTED_FILES = /\A(.*)\/(.+)-[^\.]+\.([^\.]+)\z/
     REGEXP_ASSETS_TO_CACHE_CONTROL = /-[0-9a-fA-F]{32,}$/
 
     class BucketNotFound < StandardError;

--- a/spec/unit/storage_spec.rb
+++ b/spec/unit/storage_spec.rb
@@ -140,6 +140,9 @@ describe AssetSync::Storage do
         'public/great-image.png',
         'public/great-image-82389298328.png',
         'public/great-image-a8389f9h324.png',
+        "public/new\nline.js",
+        "public/new\nline-aaaaaaaaaaa.js",
+        "public/new\nline-bbbbbbbbbbb.js",
         'public/application.js',
         'public/application-b3389d983k1.js',
         'public/application-ac387d53f31.js',
@@ -148,6 +151,8 @@ describe AssetSync::Storage do
       @remote_files = [
         'public/great-image.png',
         'public/great-image-a8389f9h324.png',
+        "public/new\nline.js",
+        "public/new\nline-aaaaaaaaaaa.js",
         'public/application.js',
         'public/application-b3389d983k1.js',
       ]
@@ -159,6 +164,7 @@ describe AssetSync::Storage do
 
       updated_nonfingerprinted_files = [
         'public/great-image.png',
+        "public/new\nline.js",
         'public/application.js',
       ]
       (@local_files - @remote_files + updated_nonfingerprinted_files).each do |file|

--- a/spec/unit/storage_spec.rb
+++ b/spec/unit/storage_spec.rb
@@ -137,17 +137,17 @@ describe AssetSync::Storage do
 
     it 'should upload updated non-fingerprinted files' do
       @local_files = [
-        'public/image.png',
-        'public/image-82389298328.png',
-        'public/image-a8389f9h324.png',
+        'public/great-image.png',
+        'public/great-image-82389298328.png',
+        'public/great-image-a8389f9h324.png',
         'public/application.js',
         'public/application-b3389d983k1.js',
         'public/application-ac387d53f31.js',
         'public',
       ]
       @remote_files = [
-        'public/image.png',
-        'public/image-a8389f9h324.png',
+        'public/great-image.png',
+        'public/great-image-a8389f9h324.png',
         'public/application.js',
         'public/application-b3389d983k1.js',
       ]
@@ -158,7 +158,7 @@ describe AssetSync::Storage do
       allow(File).to receive(:file?).and_return(true) # Pretend they all exist
 
       updated_nonfingerprinted_files = [
-        'public/image.png',
+        'public/great-image.png',
         'public/application.js',
       ]
       (@local_files - @remote_files + updated_nonfingerprinted_files).each do |file|


### PR DESCRIPTION
`upload_files` uses `get_non_fingerprinted` to determine if any non-fingerprinted files need to be uploaded because there's a new fingerprinted file. It does this by determining that if `assets/image-digest.png` needs to be uploaded then `assets/image.png` should also be uploaded, if it exists. But it faultily would determine that if `assets/great-image-digest.png` needed to be uploaded then `assets/great.png` should be uploaded if it exists instead of `assets/great-image.png`.