### PR TITLE
Add ability to directly configure the S3 ACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,11 @@ AssetSync.configure do |config|
   # Change AWS signature version. Default is 4
   # config.aws_signature_version = 4
   #
+  # Change canned ACL of uploaded object. Default is unset. Will override fog_public if set.
+  # Choose from: private | public-read | public-read-write | aws-exec-read |
+  #              authenticated-read | bucket-owner-read | bucket-owner-full-control 
+  # config.aws_acl = nil 
+  #
   # Change host option in fog (only if you need to)
   # config.fog_host = 's3.amazonaws.com'
   #
@@ -308,6 +313,11 @@ defaults: &defaults
   #
   # Change AWS signature version. Default is 4
   # aws_signature_version: 4
+  #
+  # Change canned ACL of uploaded object. Default is unset. Will override fog_public if set.
+  # Choose from: private | public-read | public-read-write | aws-exec-read |
+  #              authenticated-read | bucket-owner-read | bucket-owner-full-control 
+  # aws_acl: null
   #
   # Change host option in fog (only if you need to)
   # fog_host: "s3.amazonaws.com"

--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ The blocks are run when local files are being scanned and uploaded
 
 * **aws\_access\_key\_id**: your Amazon S3 access key
 * **aws\_secret\_access\_key**: your Amazon S3 access secret
+* **aws\_acl**: set [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) of uploaded object, will override fog_public if set
 
 #### Rackspace
 

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -37,7 +37,7 @@ module AssetSync
     attr_reader   :fog_public            # e.g. true, false, "default"
 
     # Amazon AWS
-    attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_session_token, :aws_reduced_redundancy, :aws_iam_roles, :aws_signature_version
+    attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_session_token, :aws_reduced_redundancy, :aws_iam_roles, :aws_signature_version, :aws_acl
     attr_accessor :fog_host              # e.g. 's3.amazonaws.com'
     attr_accessor :fog_port              # e.g. '9000'
     attr_accessor :fog_path_style        # e.g. true

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -37,7 +37,15 @@ module AssetSync
     attr_reader   :fog_public            # e.g. true, false, "default"
 
     # Amazon AWS
-    attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_session_token, :aws_reduced_redundancy, :aws_iam_roles, :aws_signature_version, :aws_acl
+    attr_accessor :aws_access_key_id
+    attr_accessor :aws_secret_access_key
+    attr_accessor :aws_session_token
+    attr_accessor :aws_reduced_redundancy
+    attr_accessor :aws_iam_roles
+    attr_accessor :aws_signature_version
+    attr_accessor :aws_acl
+
+    # Fog
     attr_accessor :fog_host              # e.g. 's3.amazonaws.com'
     attr_accessor :fog_port              # e.g. '9000'
     attr_accessor :fog_path_style        # e.g. true

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -229,6 +229,7 @@ module AssetSync
       self.aws_reduced_redundancy = yml["aws_reduced_redundancy"]
       self.aws_iam_roles          = yml["aws_iam_roles"]
       self.aws_signature_version  = yml["aws_signature_version"]
+      self.aws_acl                = yml["aws_acl"]
       self.rackspace_username     = yml["rackspace_username"]
       self.rackspace_auth_url     = yml["rackspace_auth_url"] if yml.has_key?("rackspace_auth_url")
       self.rackspace_api_key      = yml["rackspace_api_key"]

--- a/lib/asset_sync/engine.rb
+++ b/lib/asset_sync/engine.rb
@@ -25,6 +25,7 @@ module AssetSync
           config.aws_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY'] if ENV.has_key?('AWS_SECRET_ACCESS_KEY')
           config.aws_session_token = ENV['AWS_SESSION_TOKEN'] if ENV.has_key?('AWS_SESSION_TOKEN')
           config.aws_signature_version = ENV['AWS_SIGNATURE_VERSION'] if ENV.has_key?('AWS_SIGNATURE_VERSION')
+          config.aws_acl = ENV['AWS_ACL'] if ENV.has_key?('AWS_ACL')
           config.aws_reduced_redundancy = ENV['AWS_REDUCED_REDUNDANCY'] == true  if ENV.has_key?('AWS_REDUCED_REDUNDANCY')
 
           config.rackspace_username = ENV['RACKSPACE_USERNAME'] if ENV.has_key?('RACKSPACE_USERNAME')

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -195,7 +195,9 @@ module AssetSync
 
       # region fog_public
 
-      if config.fog_public.use_explicit_value?
+      if config.aws? && config.aws_acl
+        file[:acl] = config.aws_acl
+      elsif config.fog_public.use_explicit_value?
         file[:public] = config.fog_public.to_bool
       end
 

--- a/lib/generators/asset_sync/templates/asset_sync.rb
+++ b/lib/generators/asset_sync/templates/asset_sync.rb
@@ -11,6 +11,11 @@ if defined?(AssetSync)
     # Change AWS signature version. Default is 4
     # config.aws_signature_version = 4
     #
+    # Change canned ACL of uploaded object. Default is unset. Will override fog_public if set.
+    # Choose from: private | public-read | public-read-write | aws-exec-read |
+    #              authenticated-read | bucket-owner-read | bucket-owner-full-control 
+    # config.aws_acl = nil 
+    #
     # Change host option in fog (only if you need to)
     # config.fog_host = "s3.amazonaws.com"
     #

--- a/lib/generators/asset_sync/templates/asset_sync.yml
+++ b/lib/generators/asset_sync/templates/asset_sync.yml
@@ -10,6 +10,11 @@ defaults: &defaults
   # Change AWS signature version. Default is 4
   # aws_signature_version: 4
   #
+  # Change canned ACL of uploaded object. Default is unset. Will override fog_public if set.
+  # Choose from: private | public-read | public-read-write | aws-exec-read |
+  #              authenticated-read | bucket-owner-read | bucket-owner-full-control 
+  # aws_acl: null
+  #
   # Change host option in fog (only if you need to)
   # fog_host: "s3.amazonaws.com"
   #


### PR DESCRIPTION
Currently, the only mechanism to control the permissions of objects in S3 is via the `config.fog_public` option, which is somewhat limited.

This PR creates the `AssetSync.config.aws_acl` option, which allows the S3 Access Control List for uploaded objects to be set to specific values.

Depending on the situation, setting these more specific values can be quite useful. For instance, `config.aws_acl = 'bucket-owner-full-control'` is used in some situations to ensure that the file uploaded is accessible by the bucket's owner, which may differ from the uploader.

We need this option as the account we are uploading from is different to that which owns the bucket, so we must ensure these ACL permissions are correctly set.

Setting this config value will override the `AssetSync.config.fog_public` setting if set, as it is more specific.