### PR TITLE
Use YAML.unsafe_load if available to support Psych v4

### DIFF
--- a/lib/asset_sync/asset_sync.rb
+++ b/lib/asset_sync/asset_sync.rb
@@ -1,3 +1,5 @@
+require "yaml"
+
 module AssetSync
 
   class << self
@@ -58,6 +60,14 @@ module AssetSync
 
     def log(msg)
       stdout.puts msg unless config.log_silently?
+    end
+
+    def load_yaml(yaml)
+      if YAML.respond_to?(:unsafe_load)
+        YAML.unsafe_load(yaml)
+      else
+        YAML.load(yaml)
+      end
     end
 
     def enabled?

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -2,7 +2,6 @@
 
 require "active_model"
 require "erb"
-require "yaml"
 
 module AssetSync
   class Config
@@ -184,7 +183,7 @@ module AssetSync
     end
 
     def yml
-      @yml ||= ::YAML.load(::ERB.new(IO.read(yml_path)).result)[::Rails.env] || {}
+      @yml ||= ::AssetSync.load_yaml(::ERB.new(IO.read(yml_path)).result)[::Rails.env] || {}
     end
 
     def yml_path

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -117,7 +117,7 @@ module AssetSync
           return manifest.assets.values.map { |f| File.join(self.config.assets_prefix, f) }
         elsif File.exist?(self.config.manifest_path)
           log "Using: Manifest #{self.config.manifest_path}"
-          yml = YAML.load(IO.read(self.config.manifest_path))
+          yml = AssetSync.load_yaml(IO.read(self.config.manifest_path))
 
           return yml.map do |original, compiled|
             # Upload font originals and compiled


### PR DESCRIPTION
Psych 4.0.0 makes `YAML.load` default to safe mode (ruby/psych#487).
This cause error on parsing `config/asset_sync.yml`.
(Reproduction repo: https://github.com/fukayatsu/asset_sync-with-psych-4)

