### PR TITLE
OPER-5924 Forward-port fix for asset prefixes w/ trailing slash

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -140,7 +140,7 @@ module AssetSync
 
       log "Using: Directory Search of #{path}/#{self.config.assets_prefix}"
       Dir.chdir(path) do
-        to_load = self.config.assets_prefix.present? ? "#{self.config.assets_prefix}/**/**" : '**/**'
+        to_load = self.config.assets_prefix.present? ? File.join(self.config.assets_prefix, '/**/**') : '**/**'
         Dir[to_load]
       end
     end

--- a/lib/asset_sync/version.rb
+++ b/lib/asset_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AssetSync
-  VERSION = "2.15.1"
+  VERSION = "2.15.1.1"
 end


### PR DESCRIPTION
The bucket setup in `AssetSync::Storage#bucket` uses fuzzy matching when `config.prefix` is present. This can present a problem in some cases, as it doesn't allow for distinguishing between (e.g.) a bucket folder called `assets/` and another folder called `assets-temp/`. A situation could arise where the latter folder has thousands/millions of files and everything slows to a crawl while we wait for the bucket object to initialize.

This change allows developers to be more specific in their `config.prefix` by using a trailing slash for their folder name.

<h3>Pre-Release Requirements</h3>

- [ ] Add to TJS, verify functionality (https://github.com/Tapjoy/tapjoyserver/pull/20967)

<h3>Release Process</h3>

Given the forked nature of the repo, this is how I plan to "release" this.

- [ ] Build gem and push to Tapjoy Gemfury
- [ ] Push this branch as `v2.15.1.1` tag
- [ ] Close this PR

<h3>Notes</h3>

I plan to do an upstream PR with the change, so hopefully we can stop running a forked version of this gem.