### PR TITLE
Drop trailing slash of prefix in #get_local_files

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -140,7 +140,7 @@ module AssetSync
 
       log "Using: Directory Search of #{path}/#{self.config.assets_prefix}"
       Dir.chdir(path) do
-        to_load = self.config.assets_prefix.present? ? "#{self.config.assets_prefix}/**/**" : '**/**'
+        to_load = self.config.assets_prefix.present? ? File.join(self.config.assets_prefix, '/**/**') : '**/**'
         Dir[to_load]
       end
     end

--- a/spec/unit/storage_spec.rb
+++ b/spec/unit/storage_spec.rb
@@ -1,4 +1,5 @@
 require File.dirname(__FILE__) + '/../spec_helper'
+require 'fileutils'
 
 describe AssetSync::Storage do
   include_context "mock Rails without_yml"
@@ -447,6 +448,54 @@ describe AssetSync::Storage do
         expect(file).to receive(:destroy)
 
         storage.delete_extra_remote_files
+      end
+    end
+  end
+
+  describe '#get_local_files' do
+    around(:each) do |example|
+      Dir.mktmpdir do |public_path|
+        @public_path = public_path
+        example.call
+      end
+    end
+
+    before(:each) do
+      @config = AssetSync::Config.new
+      @config.public_path = @public_path
+      @config.prefix = 'assets'
+      @storage = AssetSync::Storage.new(@config)
+
+      Dir.mkdir("#{@public_path}/assets")
+    end
+
+    context 'with empty directory' do
+      it 'has no files' do
+        expect(@storage.get_local_files).to eq([])
+      end
+    end
+
+    context 'with non-empty directory' do
+      before(:each) do
+        FileUtils.touch("#{@public_path}/assets/application.js")
+      end
+
+      it 'lists available files' do
+        expect(@storage.get_local_files).to eq([
+          'assets/application.js'
+        ])
+      end
+
+      context 'with trailing slash on asset prefix' do
+        before(:each) do
+          @config.prefix = 'assets/'
+        end
+
+        it 'lists available files with single slashes' do
+          expect(@storage.get_local_files).to eq([
+            'assets/application.js'
+          ])
+        end
       end
     end
   end


### PR DESCRIPTION
The local filesystem glob in `AssetSync::Storage#get_local_files` uses fuzzy matching when `config.prefix` is present. This can present a problem in some cases, as it doesn't allow for distinguishing between (e.g.) a folder called `assets/` and another folder called `assets-temp/`. A situation could arise where the latter folder has thousands/millions of files and we mistakenly publish local-only files, or worse we could clobber another directory in the bucket managed in a completely different context.

This change allows developers to be more specific in their `config.prefix` by using a trailing slash for their folder name.