### PR TITLE
Fix/broken asset sync prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ defaults: &defaults
   # Ignored files. Useful if there are some files that are created dynamically on the server and you don't want to upload on deploy.
   # ignored_files: ['ignore_me.js', !ruby/regexp '/ignore_some/\d{32}\.css/']
   # Public path. To change the public directory.
-  # prefix: 'public'
+  # public_path: 'public'
   # Prefix. To change the directory to sync relative to public_path.
   # prefix: 'assets'
   # Allow custom assets to be cacheable. Note: The base filename will be matched

--- a/README.md
+++ b/README.md
@@ -343,6 +343,10 @@ defaults: &defaults
   # always_upload: ['application.js', 'application.css', !ruby/regexp '/application-/\d{32}\.css/']
   # Ignored files. Useful if there are some files that are created dynamically on the server and you don't want to upload on deploy.
   # ignored_files: ['ignore_me.js', !ruby/regexp '/ignore_some/\d{32}\.css/']
+  # Public path. To change the public directory.
+  # prefix: 'public'
+  # Prefix. To change the directory to sync relative to public_path.
+  # prefix: 'assets'
   # Allow custom assets to be cacheable. Note: The base filename will be matched
   # If you have an asset with name "app.0b1a4cd3.js", only "app.0b1a4cd3" will need to be matched
   # cache_asset_regexps: ['cache_me.js', !ruby/regexp '/cache_some\.\d{8}\.css/']

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -244,6 +244,7 @@ module AssetSync
       self.log_silently           = yml["log_silently"] if yml.has_key?("log_silently")
       self.always_upload          = yml["always_upload"] if yml.has_key?("always_upload")
       self.ignored_files          = yml["ignored_files"] if yml.has_key?("ignored_files")
+      self.prefix                 = yml["prefix"] if yml.has_key?("prefix")
       self.custom_headers         = yml["custom_headers"] if yml.has_key?("custom_headers")
       self.run_on_precompile      = yml["run_on_precompile"] if yml.has_key?("run_on_precompile")
       self.invalidate             = yml["invalidate"] if yml.has_key?("invalidate")

--- a/lib/asset_sync/engine.rb
+++ b/lib/asset_sync/engine.rb
@@ -44,21 +44,13 @@ module AssetSync
           config.enabled = (ENV['ASSET_SYNC_ENABLED'] == 'true') if ENV.has_key?('ASSET_SYNC_ENABLED')
 
           config.existing_remote_files = ENV['ASSET_SYNC_EXISTING_REMOTE_FILES'] || "keep"
-
           config.gzip_compression = (ENV['ASSET_SYNC_GZIP_COMPRESSION'] == 'true') if ENV.has_key?('ASSET_SYNC_GZIP_COMPRESSION')
           config.manifest = (ENV['ASSET_SYNC_MANIFEST'] == 'true') if ENV.has_key?('ASSET_SYNC_MANIFEST')
+          config.prefix = ENV['ASSET_SYNC_PREFIX'] if ENV.has_key?('ASSET_SYNC_PREFIX')
           config.include_manifest = (ENV['ASSET_SYNC_INCLUDE_MANIFEST'] == 'true') if ENV.has_key?('ASSET_SYNC_INCLUDE_MANIFEST')
           config.concurrent_uploads = (ENV['ASSET_SYNC_CONCURRENT_UPLOADS'] == 'true') if ENV.has_key?('ASSET_SYNC_CONCURRENT_UPLOADS')
           config.remote_file_list_cache_file_path = ENV['ASSET_SYNC_REMOTE_FILE_LIST_CACHE_FILE_PATH'] if ENV.has_key?('ASSET_SYNC_REMOTE_FILE_LIST_CACHE_FILE_PATH')
         end
-
-        config.prefix = ENV['ASSET_SYNC_PREFIX'] if ENV.has_key?('ASSET_SYNC_PREFIX')
-
-        config.existing_remote_files = ENV['ASSET_SYNC_EXISTING_REMOTE_FILES'] || "keep"
-
-        config.gzip_compression = (ENV['ASSET_SYNC_GZIP_COMPRESSION'] == 'true') if ENV.has_key?('ASSET_SYNC_GZIP_COMPRESSION')
-        config.manifest = (ENV['ASSET_SYNC_MANIFEST'] == 'true') if ENV.has_key?('ASSET_SYNC_MANIFEST')
-
       end
 
       if File.exist?( app_yaml )


### PR DESCRIPTION
# Problem

I am using asset_sync with rails application without sprockets. That means we can't call `Rails.application.config.assets.*`, so I wanted to configure the `prefix` property here https://github.com/AssetSync/asset_sync/blob/d0da75d674e4c7a7b8de3bf72ccf7fb8568b4c81/lib/asset_sync/config.rb#L195
but noticed that I can't configure `prefix` in yaml config.
Then I tried to configure it by env but `ASSET_SYNC_PREFIX` had no effect. From my investigation, I believe `ASSET_SYNC_PREFIX` env is broken from this conflict resolution commit.
https://github.com/AssetSync/asset_sync/commit/6547ec7358cb4a82b4a209569b62d50eee462e93

# Fix

* Fixed the `ASSET_SYNC_PREFIX` env configuration by moving it inside `AssetSync.configure`
* Add `prefix` configuration feature to yaml config too