### PR TITLE
Option to maintain local cache file in Remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ AssetSync.configure do |config|
   # Path to cache file to skip scanning remote
   # config.remote_file_list_cache_file_path = './.asset_sync_remote_file_list_cache.json'
   #
-  # Path to maintain remote file list in remote
+  # Path on remote storage to persist remote file list file
   # config.remote_file_list_remote_path = '/remote/asset_sync_remote_file.json'
   #
   # Fail silently.  Useful for environments such as Heroku

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ AssetSync.config.gzip_compression == ENV['ASSET_SYNC_GZIP_COMPRESSION']
 * **concurrent_uploads**: (`true, false`) when enabled, will upload the files in different Threads, this greatly improves the upload speed. **default:** `'false'`
 * **concurrent_uploads_max_threads**: when concurrent_uploads is enabled, this determines the number of threads that will be created. **default:** `10`
 * **remote_file_list_cache_file_path**: if present, use this path to cache remote file list to skip scanning remote **default:** `nil`
-* **remote_file_list_remote_path**: if present, use this path to download remote file list file to cache file list in local to skip scanning remote. useful in container environment where you cannot maintain the local file **default:** `nil`
+* **remote_file_list_remote_path**: if present, use this path to download remote file list file to cache file list in local to skip scanning remote. useful in container environment where you cannot maintain the local file, remote_file_list_cache_file_path also needed to make use of this option **default:** `nil`
 * **enabled**: (`true, false`) when false, will disable asset sync. **default:** `'true'` (enabled)
 * **ignored\_files**: an array of files to ignore e.g. `['ignore_me.js', %r(ignore_some/\d{32}\.css)]` Useful if there are some files that are created dynamically on the server and you don't want to upload on deploy **default**: `[]`
 * **cache\_asset\_regexps**: an array of files to add cache headers e.g. `['cache_me.js', %r(cache_some\.\d{8}\.css)]` Useful if there are some files that are added to sprockets assets list and need to be set as 'Cacheable' on uploaded server.  Only rails compiled regexp is matched internally **default**: `[]`

--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ AssetSync.configure do |config|
   # Path to cache file to skip scanning remote
   # config.remote_file_list_cache_file_path = './.asset_sync_remote_file_list_cache.json'
   #
+  # Path to maintain remote file list in remote
+  # config.remote_file_list_remote_path = '/remote/asset_sync_remote_file.json'
+  #
   # Fail silently.  Useful for environments such as Heroku
   # config.fail_silently = true
   #
@@ -380,6 +383,7 @@ AssetSync.config.gzip_compression == ENV['ASSET_SYNC_GZIP_COMPRESSION']
 * **concurrent_uploads**: (`true, false`) when enabled, will upload the files in different Threads, this greatly improves the upload speed. **default:** `'false'`
 * **concurrent_uploads_max_threads**: when concurrent_uploads is enabled, this determines the number of threads that will be created. **default:** `10`
 * **remote_file_list_cache_file_path**: if present, use this path to cache remote file list to skip scanning remote **default:** `nil`
+* **remote_file_list_remote_path**: if present, use this path to download remote file list file to cache file list in local to skip scanning remote. useful in container environment where you cannot maintain the local file **default:** `nil`
 * **enabled**: (`true, false`) when false, will disable asset sync. **default:** `'true'` (enabled)
 * **ignored\_files**: an array of files to ignore e.g. `['ignore_me.js', %r(ignore_some/\d{32}\.css)]` Useful if there are some files that are created dynamically on the server and you don't want to upload on deploy **default**: `[]`
 * **cache\_asset\_regexps**: an array of files to add cache headers e.g. `['cache_me.js', %r(cache_some\.\d{8}\.css)]` Useful if there are some files that are added to sprockets assets list and need to be set as 'Cacheable' on uploaded server.  Only rails compiled regexp is matched internally **default**: `[]`

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -28,6 +28,7 @@ module AssetSync
     attr_accessor :concurrent_uploads
     attr_accessor :concurrent_uploads_max_threads
     attr_accessor :remote_file_list_cache_file_path
+    attr_accessor :remote_file_list_remote_path
 
     # FOG configuration
     attr_accessor :fog_provider          # Currently Supported ['AWS', 'Rackspace']
@@ -107,6 +108,7 @@ module AssetSync
       self.concurrent_uploads = false
       self.concurrent_uploads_max_threads = 10
       self.remote_file_list_cache_file_path = nil
+      self.remote_file_list_remote_path = nil
       @additional_local_file_paths_procs = []
 
       load_yml! if defined?(::Rails) && yml_exists?
@@ -253,6 +255,7 @@ module AssetSync
       self.concurrent_uploads     = yml['concurrent_uploads'] if yml.has_key?('concurrent_uploads')
       self.concurrent_uploads_max_threads = yml['concurrent_uploads_max_threads'] if yml.has_key?('concurrent_uploads_max_threads')
       self.remote_file_list_cache_file_path = yml['remote_file_list_cache_file_path'] if yml.has_key?('remote_file_list_cache_file_path')
+      self.remote_file_list_remote_path = yml['remote_file_list_remote_path'] if yml.has_key?('remote_file_list_remote_path')
 
       self.azure_storage_account_name = yml['azure_storage_account_name'] if yml.has_key?("azure_storage_account_name")
       self.azure_storage_access_key   = yml['azure_storage_access_key'] if yml.has_key?("azure_storage_access_key")

--- a/lib/asset_sync/engine.rb
+++ b/lib/asset_sync/engine.rb
@@ -50,6 +50,7 @@ module AssetSync
           config.include_manifest = (ENV['ASSET_SYNC_INCLUDE_MANIFEST'] == 'true') if ENV.has_key?('ASSET_SYNC_INCLUDE_MANIFEST')
           config.concurrent_uploads = (ENV['ASSET_SYNC_CONCURRENT_UPLOADS'] == 'true') if ENV.has_key?('ASSET_SYNC_CONCURRENT_UPLOADS')
           config.remote_file_list_cache_file_path = ENV['ASSET_SYNC_REMOTE_FILE_LIST_CACHE_FILE_PATH'] if ENV.has_key?('ASSET_SYNC_REMOTE_FILE_LIST_CACHE_FILE_PATH')
+          config.remote_file_list_remote_path = ENV['ASSET_SYNC_REMOTE_FILE_LIST_REMOTE_PATH'] if ENV.has_key?('ASSET_SYNC_REMOTE_FILE_LIST_REMOTE_PATH')
         end
 
         config.prefix = ENV['ASSET_SYNC_PREFIX'] if ENV.has_key?('ASSET_SYNC_PREFIX')

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -110,6 +110,7 @@ module AssetSync
 
     def update_remote_file_list_in_remote
       return if ignore_existing_remote_files?
+      return unless remote_file_list_remote_path
       return unless remote_file_list_cache_file_path
       log "Updating file list file in remote"
       remote_file = bucket.files.new({
@@ -342,7 +343,7 @@ module AssetSync
       end
 
       update_remote_file_list_cache(local_files_to_upload)
-      update_remote_file_list_in_remote if remote_file_list_remote_path
+      update_remote_file_list_in_remote
     end
 
     def sync

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -78,7 +78,7 @@ module AssetSync
 
       if remote_file_list_remote_path && remote_file_list_cache_file_path
         log "Downloading file list file from remote"
-        remote_cache_file = directories.files.get(remote_file_list_remote_path)
+        remote_cache_file = bucket.files.get(remote_file_list_remote_path)
         if remote_cache_file
           File.open(remote_file_list_cache_file_path, 'w') do |local_file|
             local_file.write(remote_cache_file.body)
@@ -112,7 +112,7 @@ module AssetSync
       return if ignore_existing_remote_files?
       return unless remote_file_list_cache_file_path
       log "Updating file list file in remote"
-      remote_file = directory.files.new({
+      remote_file = bucket.files.new({
         :key    => remote_file_list_remote_path,
         :body   => File.open(remote_file_list_cache_file_path)
       })

--- a/lib/generators/asset_sync/templates/asset_sync.rb
+++ b/lib/generators/asset_sync/templates/asset_sync.rb
@@ -81,6 +81,9 @@ if defined?(AssetSync)
     # Path to cache file to skip scanning remote
     # config.remote_file_list_cache_file_path = './.asset_sync_remote_file_list_cache.json'
     #
+    # Path to maintain remote file list in remote
+    # config.remote_file_list_remote_path = '/remote/asset_sync_remote_file.json'
+    #
     # Fail silently.  Useful for environments such as Heroku
     # config.fail_silently = true
     #

--- a/lib/generators/asset_sync/templates/asset_sync.rb
+++ b/lib/generators/asset_sync/templates/asset_sync.rb
@@ -81,7 +81,7 @@ if defined?(AssetSync)
     # Path to cache file to skip scanning remote
     # config.remote_file_list_cache_file_path = './.asset_sync_remote_file_list_cache.json'
     #
-    # Path to maintain remote file list in remote
+    # Path on remote storage to persist remote file list file
     # config.remote_file_list_remote_path = '/remote/asset_sync_remote_file.json'
     #
     # Fail silently.  Useful for environments such as Heroku

--- a/spec/unit/asset_sync_spec.rb
+++ b/spec/unit/asset_sync_spec.rb
@@ -94,6 +94,10 @@ describe AssetSync do
     it "should default asset_regexps to empty array" do
       expect(AssetSync.config.cache_asset_regexps).to eq([])
     end
+
+    it "should default remote_file_list_remote_path to nil" do
+      expect(AssetSync.config.remote_file_list_remote_path).to be_nil
+    end
   end
 
   describe 'from yml' do


### PR DESCRIPTION
With `remote_file_list_cache_file_path` options we could be able to reduce and sync time by 30 minutes.

Maintaining the local file is difficult in the docker environment, so in this PR providing the option to have the cache file in remote (`remote_file_list_remote_path`) as well. Which will be downloaded during asset sync if path is configured and its creates a local file for further references in the sync. Once after the sync is completed, updated local cache file will be uploaded back to configured remote path. 

This remote cache file will be maintained in the path configured using `remote_file_list_remote_path` inside `fog_directory`