### PR TITLE
Add fog_options to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Nothing
+- Add `fog_options` configuration option.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ AssetSync.configure do |config|
   #
   # Change canned ACL of uploaded object. Default is unset. Will override fog_public if set.
   # Choose from: private | public-read | public-read-write | aws-exec-read |
-  #              authenticated-read | bucket-owner-read | bucket-owner-full-control 
-  # config.aws_acl = nil 
+  #              authenticated-read | bucket-owner-read | bucket-owner-full-control
+  # config.aws_acl = nil
   #
   # Change host option in fog (only if you need to)
   # config.fog_host = 's3.amazonaws.com'
@@ -255,6 +255,9 @@ AssetSync.configure do |config|
   #
   # Use http instead of https.
   # config.fog_scheme = 'http'
+  #
+  # Extra fog options.
+  # config.fog_options = {}
   #
   # Automatically replace files with their equivalent gzip compressed version
   # config.gzip_compression = true
@@ -322,7 +325,7 @@ defaults: &defaults
   #
   # Change canned ACL of uploaded object. Default is unset. Will override fog_public if set.
   # Choose from: private | public-read | public-read-write | aws-exec-read |
-  #              authenticated-read | bucket-owner-read | bucket-owner-full-control 
+  #              authenticated-read | bucket-owner-read | bucket-owner-full-control
   # aws_acl: null
   #
   # Change host option in fog (only if you need to)
@@ -436,6 +439,7 @@ The blocks are run when local files are being scanned and uploaded
 
 * **fog\_region**: the region your storage bucket is in e.g. *eu-west-1* (AWS),  *ord* (Rackspace), *japanwest* (Azure Blob)
 * **fog\_path\_style**: To use buckets with dot in names, check https://github.com/fog/fog/issues/2381#issuecomment-28088524
+* **fog\_options**: For extra fog options.
 
 #### AWS
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ AssetSync.configure do |config|
   # config.fog_scheme = 'http'
   #
   # Extra fog options.
+  # Overrides any existing value (even those set by AssetSync)
   # config.fog_options = {}
   #
   # Automatically replace files with their equivalent gzip compressed version
@@ -439,7 +440,7 @@ The blocks are run when local files are being scanned and uploaded
 
 * **fog\_region**: the region your storage bucket is in e.g. *eu-west-1* (AWS),  *ord* (Rackspace), *japanwest* (Azure Blob)
 * **fog\_path\_style**: To use buckets with dot in names, check https://github.com/fog/fog/issues/2381#issuecomment-28088524
-* **fog\_options**: For extra fog options.
+* **fog\_options**: For extra fog options. Overrides any existing value (even those set by AssetSync)
 
 #### AWS
 

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -35,6 +35,7 @@ module AssetSync
     attr_accessor :fog_directory         # e.g. 'the-bucket-name'
     attr_accessor :fog_region            # e.g. 'eu-west-1'
     attr_reader   :fog_public            # e.g. true, false, "default"
+    attr_accessor :fog_options           # e.g. { enable_signature_v4_streaming: true }
 
     # Amazon AWS
     attr_accessor :aws_access_key_id
@@ -338,6 +339,7 @@ module AssetSync
         raise ArgumentError, "AssetSync Unknown provider: #{fog_provider} only AWS, Rackspace and Google are supported currently."
       end
 
+      options.merge!(@fog_options) if @fog_options
       options
     end
 

--- a/spec/unit/asset_sync_spec.rb
+++ b/spec/unit/asset_sync_spec.rb
@@ -278,6 +278,28 @@ describe AssetSync do
     end
   end
 
+  describe 'with fog_options' do
+    before(:each) do
+      AssetSync.config = AssetSync::Config.new
+      AssetSync.configure do |config|
+        config.fog_provider = 'AWS'
+        config.fog_region = 'eu-west-1'
+        config.fog_path_style = 'true'
+        config.fog_options = { enable_signature_v4_streaming: true }
+      end
+    end
+
+    it "assigns fog_options" do
+      AssetSync.config.fog_options = { enable_signature_v4_streaming: true }
+      expect(AssetSync.config.fog_options).to include(
+        provider: 'AWS',
+        region: 'eu-west-1',
+        path_style: 'true',
+        enable_signature_v4_streaming: true,
+      )
+    end
+  end
+
   describe 'with invalid yml' do
     before(:each) do
       set_rails_root('with_invalid_yml')


### PR DESCRIPTION
Closes #430

I went for the more flexible `fog_options`. It’s more versatile and allows setting (or overriding any fog option). The drawback is that it can’t be set using environment variables.