### PR TITLE
Respect explicitly configured manifest path for modern Rails/Sprockets

### DIFF
--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -117,7 +117,7 @@ module AssetSync
     end
 
     def manifest_path
-      if ActionView::Base.respond_to?(:assets_manifest)
+      if defined?(ActionView) && ActionView::Base.respond_to?(:assets_manifest)
         ::Rails.application.config.assets.manifest
       else
         directory =

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -117,9 +117,13 @@ module AssetSync
     end
 
     def manifest_path
-      directory =
+      if ActionView::Base.respond_to?(:assets_manifest)
+        ::Rails.application.config.assets.manifest
+      else
+        directory =
         ::Rails.application.config.assets.manifest || default_manifest_directory
-      File.join(directory, "manifest.yml")
+        File.join(directory, "manifest.yml")
+      end
     end
 
     def gzip?

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -59,7 +59,7 @@ module AssetSync
       return [] unless self.config.include_manifest
 
       if ActionView::Base.respond_to?(:assets_manifest)
-        manifest = Sprockets::Manifest.new(ActionView::Base.assets_manifest.environment, ActionView::Base.assets_manifest.dir)
+        manifest = Sprockets::Manifest.new(ActionView::Base.assets_manifest.environment, ActionView::Base.assets_manifest.dir, self.config.manifest_path)
         manifest_path = manifest.filename
       else
         manifest_path = self.config.manifest_path
@@ -139,7 +139,7 @@ module AssetSync
       if self.config.manifest
         if ActionView::Base.respond_to?(:assets_manifest)
           log "Using: Rails 4.0 manifest access"
-          manifest = Sprockets::Manifest.new(ActionView::Base.assets_manifest.environment, ActionView::Base.assets_manifest.dir)
+          manifest = Sprockets::Manifest.new(ActionView::Base.assets_manifest.environment, ActionView::Base.assets_manifest.dir, self.config.manifest_path)
           return manifest.assets.values.map { |f| File.join(self.config.assets_prefix, f) }
         elsif File.exist?(self.config.manifest_path)
           log "Using: Manifest #{self.config.manifest_path}"

--- a/spec/unit/asset_sync_spec.rb
+++ b/spec/unit/asset_sync_spec.rb
@@ -258,6 +258,11 @@ describe AssetSync do
       Rails.application.config.assets.prefix = 'custom_assets'
       expect(AssetSync.config.manifest_path).to match(/public\/custom_assets\/manifest.yml/)
     end
+
+    it "config.manifest_path should point to explicit path" do
+      Rails.application.config.assets.manifest = 'config/manifest.json'
+      expect(AssetSync.config.manifest_path).to start_with('config/manifest.json')
+    end
   end
 
   describe 'with cache_asset_regexps' do


### PR DESCRIPTION
In our Rails 6/7 apps that use Sprockets 3/4 we configure manifest path explicitly like so:

```
config.assets.manifest = Rails.root.join("config/manifest.json")
```

Because of that `asset_sync` does not work properly because it does not pick up proper manifest, since it's located out of assets directory. Here is relevant code in sprockets source:

https://github.com/rails/sprockets/blob/3.x/lib/sprockets/manifest.rb#L54-L63

So for us the solution was to explicitly path manifest path (which is nil unless defined explicitly) as a 3rd argument to `Sprockets::Manifest.new` which actually makes it work. This works for both Sprockets 3 and 4. 

We've been running this patch for years now. Hopefully this makes sense and this contribution gets accepted. There are no specs for manifest-related code so I was only able to add a spec for manifest path.

Also, looks like `manifest.yml` is not a thing from Rails 4: https://github.com/rails/sprockets-rails#changes-from-rails-3x
So maybe that is something to be cleaned up.