### PR TITLE
Avoid duplicate files in remote files list cache

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -108,7 +108,7 @@ module AssetSync
       return if ignore_existing_remote_files?
 
       File.open(self.remote_file_list_cache_file_path, 'w') do |file|
-        uploaded = local_files_to_upload + remote_files
+        uploaded = (local_files_to_upload + remote_files).uniq
         file.write(uploaded.to_json)
       end
     end


### PR DESCRIPTION
Files on the "always_update" list would show more than once if duplicate entries aren't removed.

After the first upload, files that are in the `always_upload` list would start showing up more than once on the list of files. This doesn't cause a real problem but the list of files is not really accurate. Adding this `uniq` solves the problem.