### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/asset_sync

### DIFF
--- a/asset_sync.gemspec
+++ b/asset_sync.gemspec
@@ -39,4 +39,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+
+  s.metadata["changelog_uri"] = s.homepage + "/blob/master/CHANGELOG.md"
 end

--- a/asset_sync.gemspec
+++ b/asset_sync.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Simon Hamilton", "David Rice", "Phil McClure", "Toby Osbourn"]
   s.email       = ["shamilton@rumblelabs.com", "me@davidjrice.co.uk", "pmcclure@rumblelabs.com", "tosbourn@rumblelabs.com"]
-  s.homepage    = "https://github.com/rumblelabs/asset_sync"
+  s.homepage    = "https://github.com/AssetSync/asset_sync"
   s.summary     = %q{Synchronises Assets in a Rails 3 application and Amazon S3/Cloudfront and Rackspace Cloudfiles}
   s.description = %q{After you run assets:precompile your compiled assets will be synchronised with your S3 bucket.}
 
@@ -40,5 +40,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.metadata["changelog_uri"] = s.homepage + "/blob/master/CHANGELOG.md"
+  s.metadata["changelog_uri"] = "#{s.homepage}/blob/master/CHANGELOG.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/asset_sync which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata